### PR TITLE
Feature/dat payload attributes

### DIFF
--- a/codes/Audience.ttl
+++ b/codes/Audience.ttl
@@ -1,0 +1,12 @@
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>  .
+@prefix owl: <http://www.w3.org/2002/07/owl#>  .
+@prefix ids: <https://w3id.org/idsa/core/> .
+@prefix idsc: <https://w3id.org/idsa/code/> .
+
+# Instances of class ids:Audience
+# -------------------------------
+
+idsc:IDS_CONNECTORS_ALL 
+    a ids:Audience ;
+    rdfs:label "IDS_CONNECTORS_ALL";
+.

--- a/codes/LeftOperand.ttl
+++ b/codes/LeftOperand.ttl
@@ -38,7 +38,7 @@ idsc:STATE a ids:LeftOperand;
     .
     
 # space
-ids:ABSOLUTE_SPATIAL_POSITION a ids:LeftOperand ;
+idsc:ABSOLUTE_SPATIAL_POSITION a ids:LeftOperand ;
     rdfs:seeAlso odrl:absoluteSpatialPosition ;
     rdfs:label "Absolute geo-spatial position"@en ;
     rdfs:comment "The current geospatial position of the *consuming connector*. In case the connector only appears as a virtual entity, the physical location of the hosting server is referenced. Allowed operators are idsc:in. No other spatial operators (close to, north of, etc.) are currently allowed."@en ;
@@ -51,7 +51,7 @@ idsc:USER a ids:LeftOperand ;
     .
 
 #
-ids:PURPOSE a ids:LeftOperand;
+idsc:PURPOSE a ids:LeftOperand;
     rdfs:seeAlso odrl:purpose;
     rdfs:label "purpose"@en ;
     rdfs:comment "A defined purpose for exercising the action of the Rule. Use with idsc:IN or idsc:SAME_AS and RDF Resources."@en ;
@@ -64,16 +64,16 @@ idsc:COUNT a ids:LeftOperand;
     rdfs:comment "Numeric count of executions of the Rule. Operators can be idsc:LT, idsc:LTEQ, idsc:EQ, idsc:GT, idsc:GTEQ. Datatype is xsd:double."@en ; 
     .
 
-ids:QUANTITY a ids:LeftOperand;
+idsc:QUANTITY a ids:LeftOperand;
     rdfs:label "quantity";
     rdfs:comment "Quantity limitation for exercising the action of the Rule. Operators can be idsc:LT, idsc:LTEQ, idsc:EQ, idsc:GT, idsc:GTEQ. Datatype is xsd:double.".
 
-ids:RECURRENCE_RATE a ids:LeftOperand;
+idsc:RECURRENCE_RATE a ids:LeftOperand;
     rdfs:label "recurrence rate";
     rdfs:comment "The limit how often exercising the action of the Rule may be possible. Operators can be idsc:LT, idsc:LTEQ, idsc:EQ, idsc:GT, idsc:GTEQ. Datatype is xsd:double.".
     
 # certification level
-ids:SECURITY_LEVEL a ids:LeftOperand;
+idsc:SECURITY_LEVEL a ids:LeftOperand;
     rdfs:label "security level";
     rdfs:comment "The security level the consuming connector must have. Use together with idsc:SAME_AS or idsc:IN. The value decides which attribute dimension is regarded."@en ;
     .

--- a/model/infrastructure/Connector.ttl
+++ b/model/infrastructure/Connector.ttl
@@ -85,7 +85,9 @@ ids:extendedGuarantee a owl:ObjectProperty;
     rdfs:comment "Reference to a security guarantee that, if used in combination with a security profile instance, overrides the respective guarantee of the given predefined instance."@en.
 
 ids:transportCertsSha256 a owl:DatatypeProperty;
-    rdfs:domain ids:Connector;
+    rdfs:domain [ rdf:type owl:Class ;
+                owl:unionOf ( ids:Connector ids:JwtPayload)
+              ] ;
     rdfs:range xsd:string;
     rdfs:label "transportCertsSha256"@en;
     rdfs:comment "Separate certificates for IDS identification and transport encryption opens an attack vector for relay attacks. In order to prevent these attacks, a binding of this transport certificates to the connector is required. The inclusion of SHA256 fingerprints of currently valid transport certificates, mainly into the DAT, enables the client to relate the transport layer security with the IDS interactions."@en.

--- a/model/infrastructure/Connector.ttl
+++ b/model/infrastructure/Connector.ttl
@@ -29,6 +29,14 @@ ids:Connector
         idsm:relationType idsm:OneToMany;
     ]; 
     idsm:validation [
+        idsm:forProperty ids:extendedGuarantee ;
+        idsm:relationType idsm:OneToMany;
+    ]; 
+    idsm:validation [
+        idsm:forProperty ids:securityProfile;
+        idsm:constraint idsm:NotNull;
+    ]; 
+    idsm:validation [
         idsm:forProperty ids:hasAgents;
         idsm:relationType idsm:OneToMany;
     ].
@@ -61,13 +69,17 @@ ids:defaultHost
     rdfs:comment "Indicates the default host that should be used for basic infrastructure interactions, e.g., providing the self description."@en.
 
 ids:securityProfile a owl:ObjectProperty;
-    rdfs:domain ids:Connector;
+    rdfs:domain [ rdf:type owl:Class ;
+                owl:unionOf ( ids:Connector ids:JwtPayload)
+              ] ;
     rdfs:range ids:SecurityProfile;
     rdfs:label "securityProfile"@en;
     rdfs:comment "The SecurityProfile supported by the Connector."@en.
     
 ids:extendedGuarantee a owl:ObjectProperty;
-    rdfs:domain ids:Connector;
+    rdfs:domain [ rdf:type owl:Class ;
+                owl:unionOf ( ids:Connector ids:JwtPayload)
+              ] ;
     rdfs:range ids:SecurityGuarantee;
     rdfs:label "extended guarantee"@en;
     rdfs:comment "Reference to a security guarantee that, if used in combination with a security profile instance, overrides the respective guarantee of the given predefined instance."@en.

--- a/model/security/Token.ttl
+++ b/model/security/Token.ttl
@@ -41,6 +41,42 @@ ids:JwtPayload a owl:Class ;
     rdfs:label "JWT Payload"@en ;
     rdfs:comment "The payload of an JSON Web Token as a RDF class. Is used as the common parent of e.g. DatPayload and DatRequestPayload."@en ;
     idsm:abstract true ;
+    idsm:validation [
+        idsm:forProperty ids:aud;
+        idsm:constraint idsm:NotNull;
+    ] ;
+    idsm:validation [
+        idsm:forProperty ids:sub;
+        idsm:constraint idsm:NotNull;
+    ] ;
+    idsm:validation [
+        idsm:forProperty ids:nbf;
+        idsm:constraint idsm:NotNull;
+    ] ;
+    idsm:validation [
+        idsm:forProperty ids:exp;
+        idsm:constraint idsm:NotNull;
+    ];
+    idsm:validation [
+        idsm:forProperty ids:iat;
+        idsm:constraint idsm:NotNull;
+    ];
+    idsm:validation [
+        idsm:forProperty ids:scope;
+        idsm:constraint idsm:NotNull;
+    ];
+    idsm:validation [
+        idsm:forProperty ids:securityProfile;
+        idsm:constraint idsm:NotNull;
+    ];
+    idsm:validation [
+        idsm:forProperty ids:extendedGuarantee;
+        idsm:relationType idsm:OneToMany;
+    ];
+    idsm:validation [
+        idsm:forProperty ids:transportCertsSha256;
+        idsm:relationType idsm:OneToMany;
+    ]; 
     .
 
 
@@ -56,41 +92,9 @@ ids:DatPayload
         idsm:constraint idsm:NotNull;
     ] ;
     idsm:validation [
-        idsm:forProperty ids:aud;
-        idsm:constraint idsm:NotNull;
-    ] ;
-    idsm:validation [
         idsm:forProperty ids:iss;
         idsm:constraint idsm:NotNull;
     ] ;
-    idsm:validation [
-        idsm:forProperty ids:sub;
-        idsm:constraint idsm:NotNull;
-    ] ;
-    idsm:validation [
-        idsm:forProperty ids:nbf;
-        idsm:constraint idsm:NotNull;
-    ] ;
-    idsm:validation [
-        idsm:forProperty ids:exp;
-        idsm:constraint idsm:NotNull;
-    ];
-    idsm:validation [
-        idsm:forProperty ids:iat;
-        idsm:constraint idsm:NotNull;
-    ];
-    idsm:validation [
-        idsm:forProperty ids:scope;
-        idsm:constraint idsm:NotNull;
-    ];
-    idsm:validation [
-        idsm:forProperty ids:securityProfile;
-        idsm:constraint idsm:NotNull;
-    ];
-    idsm:validation [
-        idsm:forProperty ids:extendedGuarantee;
-        idsm:relationType idsm:OneToMany;
-    ];
 .
 
 
@@ -100,42 +104,6 @@ ids:DatRequestPayload
     rdfs:label "DAT Request Payload"@en ;
     rdfs:comment "The Dynamic Attribute Token (DAT) *Request* Payload is the JSON Element of any DAT containing the claims of the token bearer. This payload itself is a JSON-LD encoded RDF class with a defined set of attributes. These attributes are either defined by RFC 7519 or by the IDS Information Model. As a direct consequence of regarding the DAT Payload as JSON-LD, *all* DAT Payloads must have exactly one \"@context\" attribute with the IDS context URI as its value and a \"@type\" with ids:DatPayload as its value. Note that, different to the DatPayload, the DatRequestPayload contains the *self-claims* of a connector and is not yet signed by any DAPS. Consequently, no other connector must accept a DatRequest object as a DAT. A DatRequest and its contained DatRequestPayload is *only* intended for interactions with a DAPS and *nothing else*!"@en ;
     rdfs:seeAlso <https://tools.ietf.org/html/rfc7519> ;
-    idsm:validation [
-        idsm:forProperty ids:aud;
-        idsm:constraint idsm:NotNull;
-    ] ;
-    idsm:validation [
-        idsm:forProperty ids:iss;
-        idsm:constraint idsm:NotNull;
-    ] ;
-    idsm:validation [
-        idsm:forProperty ids:sub;
-        idsm:constraint idsm:NotNull;
-    ] ;
-    idsm:validation [
-        idsm:forProperty ids:nbf;
-        idsm:constraint idsm:NotNull;
-    ] ;
-    idsm:validation [
-        idsm:forProperty ids:exp;
-        idsm:constraint idsm:NotNull;
-    ];
-    idsm:validation [
-        idsm:forProperty ids:iat;
-        idsm:constraint idsm:NotNull;
-    ];
-    idsm:validation [
-        idsm:forProperty ids:scope;
-        idsm:constraint idsm:NotNull;
-    ];
-    idsm:validation [
-        idsm:forProperty ids:securityProfile;
-        idsm:constraint idsm:NotNull;
-    ];
-    idsm:validation [
-        idsm:forProperty ids:extendedGuarantee;
-        idsm:relationType idsm:OneToMany;
-    ];
     .
 
 
@@ -209,4 +177,3 @@ ids:tokenFormat a owl:ObjectProperty;
     rdfs:domain ids:Token;
     rdfs:range ids:TokenFormat;
     rdfs:comment "Describes the format of the authentication token."@en.
-

--- a/model/security/Token.ttl
+++ b/model/security/Token.ttl
@@ -37,10 +37,19 @@ ids:TokenFormat a owl:Class;
     rdfs:comment "Possible formats for (security-related) tokens."@en.
 
 
+ids:JwtPayload a owl:Class ;
+    rdfs:label "JWT Payload"@en ;
+    rdfs:comment "The payload of an JSON Web Token as a RDF class. Is used as the common parent of e.g. DatPayload and DatRequestPayload."@en ;
+    idsm:abstract true ;
+    .
+
+
+
 ids:DatPayload
     a owl:Class ;
+    rdfs:subClassOf ids:JwtPayload ;
     rdfs:label "DAT Payload"@en ;
-    rdfs:comment "The Dynamic Attribute Token (DAT) Payload is the JSON Element of any DAT containing the claims of the token bearer. This payload itself is a JSON-LD encoded RDF class with a defined set of attributes. These attributes are iether defined by RFC 7519 or by the IDS Information Model. As a direct consequence of the regardance of the DAT Payload as JSON-LD, *all* DAT Payloads must have exactly one \"@context\" attribute with the IDS context URI as its value and a \"@type\" with ids:DatPayload as its value."@en ;
+    rdfs:comment "The Dynamic Attribute Token (DAT) Payload is the JSON Element of any DAT containing the claims of the token bearer. This payload itself is a JSON-LD encoded RDF class with a defined set of attributes. These attributes are either defined by RFC 7519 or by the IDS Information Model. As a direct consequence of regarding the DAT Payload as JSON-LD, *all* DAT Payloads must have exactly one \"@context\" attribute with the IDS context URI as its value and a \"@type\" with ids:DatPayload as its value."@en ;
     rdfs:seeAlso <https://tools.ietf.org/html/rfc7519> ;
     idsm:validation [
         idsm:forProperty ids:referringConnector;
@@ -66,7 +75,68 @@ ids:DatPayload
         idsm:forProperty ids:exp;
         idsm:constraint idsm:NotNull;
     ];
+    idsm:validation [
+        idsm:forProperty ids:iat;
+        idsm:constraint idsm:NotNull;
+    ];
+    idsm:validation [
+        idsm:forProperty ids:scope;
+        idsm:constraint idsm:NotNull;
+    ];
+    idsm:validation [
+        idsm:forProperty ids:securityProfile;
+        idsm:constraint idsm:NotNull;
+    ];
+    idsm:validation [
+        idsm:forProperty ids:extendedGuarantee;
+        idsm:relationType idsm:OneToMany;
+    ];
 .
+
+
+ids:DatRequestPayload
+    a owl:Class ;
+    rdfs:subClassOf ids:JwtPayload ;
+    rdfs:label "DAT Request Payload"@en ;
+    rdfs:comment "The Dynamic Attribute Token (DAT) *Request* Payload is the JSON Element of any DAT containing the claims of the token bearer. This payload itself is a JSON-LD encoded RDF class with a defined set of attributes. These attributes are either defined by RFC 7519 or by the IDS Information Model. As a direct consequence of regarding the DAT Payload as JSON-LD, *all* DAT Payloads must have exactly one \"@context\" attribute with the IDS context URI as its value and a \"@type\" with ids:DatPayload as its value. Note that, different to the DatPayload, the DatRequestPayload contains the *self-claims* of a connector and is not yet signed by any DAPS. Consequently, no other connector must accept a DatRequest object as a DAT. A DatRequest and its contained DatRequestPayload is *only* intended for interactions with a DAPS and *nothing else*!"@en ;
+    rdfs:seeAlso <https://tools.ietf.org/html/rfc7519> ;
+    idsm:validation [
+        idsm:forProperty ids:aud;
+        idsm:constraint idsm:NotNull;
+    ] ;
+    idsm:validation [
+        idsm:forProperty ids:iss;
+        idsm:constraint idsm:NotNull;
+    ] ;
+    idsm:validation [
+        idsm:forProperty ids:sub;
+        idsm:constraint idsm:NotNull;
+    ] ;
+    idsm:validation [
+        idsm:forProperty ids:nbf;
+        idsm:constraint idsm:NotNull;
+    ] ;
+    idsm:validation [
+        idsm:forProperty ids:exp;
+        idsm:constraint idsm:NotNull;
+    ];
+    idsm:validation [
+        idsm:forProperty ids:iat;
+        idsm:constraint idsm:NotNull;
+    ];
+    idsm:validation [
+        idsm:forProperty ids:scope;
+        idsm:constraint idsm:NotNull;
+    ];
+    idsm:validation [
+        idsm:forProperty ids:securityProfile;
+        idsm:constraint idsm:NotNull;
+    ];
+    idsm:validation [
+        idsm:forProperty ids:extendedGuarantee;
+        idsm:relationType idsm:OneToMany;
+    ];
+    .
 
 
 # Properties
@@ -75,34 +145,34 @@ ids:DatPayload
 
 ids:aud a owl:DatatypeProperty;
     rdfs:label "aud"@en;
-    rdfs:domain ids:DatPayload;
+    rdfs:domain ids:JwtPayload;
     rdfs:range xsd:string ;
     rdfs:seeAlso <https://tools.ietf.org/html/rfc7519#section-4.1.3> ;
     rdfs:comment "The 'aud' (audience) claim identifies the recipients that the JWT is intended for."@en.
 
 ids:exp a owl:DatatypeProperty;
     rdfs:label "exp"@en;
-    rdfs:domain ids:DatPayload;
+    rdfs:domain ids:JwtPayload;
     rdfs:range xsd:integer ; 
     rdfs:seeAlso <https://tools.ietf.org/html/rfc7519#section-4.1.4> ;
     rdfs:comment "The 'exp' (expiration time) claim identifies the expiration time on or after which the JWT MUST NOT be accepted for processing."@en.
 
 ids:iat a owl:DatatypeProperty;
     rdfs:label "iat"@en;
-    rdfs:domain ids:DatPayload;
+    rdfs:domain ids:JwtPayload;
     rdfs:range xsd:integer ; 
     rdfs:comment "The 'iat' (issued at) claim contains the point in time when the JWT was created."@en.
 
 ids:iss a owl:DatatypeProperty;
     rdfs:label "iss"@en;
-    rdfs:domain ids:DatPayload;
+    rdfs:domain ids:JwtPayload;
     rdfs:range xsd:string ;
     rdfs:seeAlso <https://tools.ietf.org/html/rfc7519#section-4.1.1> ;
     rdfs:comment "The 'iss' (issuer) claim identifies the principal that issued the JWT."@en.
 
 ids:nbf a owl:DatatypeProperty;
     rdfs:label "nbf"@en;
-    rdfs:domain ids:DatPayload;
+    rdfs:domain ids:JwtPayload;
     rdfs:range xsd:integer ; 
     rdfs:seeAlso <https://tools.ietf.org/html/rfc7519#section-4.1.5> ;
     rdfs:comment "The 'aud' (audience) claim identifies the recipients that the JWT is intended for."@en.
@@ -114,9 +184,16 @@ ids:referringConnector a owl:DatatypeProperty;
     rdfs:range ids:Connector; 
     rdfs:comment "The RDF connector entity as referred to by the DAT, with its URI included as the value. The value MUST be its accessible URI."@en.
 
+ids:scope a owl:DatatypeProperty;
+    rdfs:label "scope"@en;
+    rdfs:domain ids:JwtPayload;
+    rdfs:range xsd:string ;
+    rdfs:seeAlso <https://tools.ietf.org/html/rfc7519#section-4.1.2> ;
+    rdfs:comment "Currently, the scope is limited to 'Connector' but can be used for scoping purposes in the future. Scope is currently fixed to 'https://w3id.org/idsa/core/Connector'."@en.
+
 ids:sub a owl:DatatypeProperty;
     rdfs:label "sub"@en;
-    rdfs:domain ids:DatPayload;
+    rdfs:domain ids:JwtPayload;
     rdfs:range xsd:string ;
     rdfs:seeAlso <https://tools.ietf.org/html/rfc7519#section-4.1.2> ;
     rdfs:comment "The 'sub' (subject) claim identifies the principal that is the subject of the JWT."@en.

--- a/model/security/Token.ttl
+++ b/model/security/Token.ttl
@@ -156,7 +156,7 @@ ids:nbf a owl:DatatypeProperty;
 ids:referringConnector a owl:DatatypeProperty;
     rdfs:label "referringConnector"@en;
     idsm:referenceByUri true;
-    rdfs:domain ids:DatPayload;
+    rdfs:domain ids:JwtPayload;
     rdfs:range ids:Connector; 
     rdfs:comment "The RDF connector entity as referred to by the DAT, with its URI included as the value. The value MUST be its accessible URI."@en.
 

--- a/model/security/Token.ttl
+++ b/model/security/Token.ttl
@@ -105,16 +105,24 @@ ids:DatRequestPayload
     rdfs:comment "The Dynamic Attribute Token (DAT) *Request* Payload is the JSON Element of any DAT containing the claims of the token bearer. This payload itself is a JSON-LD encoded RDF class with a defined set of attributes. These attributes are either defined by RFC 7519 or by the IDS Information Model. As a direct consequence of regarding the DAT Payload as JSON-LD, *all* DAT Payloads must have exactly one \"@context\" attribute with the IDS context URI as its value and a \"@type\" with ids:DatPayload as its value. Note that, different to the DatPayload, the DatRequestPayload contains the *self-claims* of a connector and is not yet signed by any DAPS. Consequently, no other connector must accept a DatRequest object as a DAT. A DatRequest and its contained DatRequestPayload is *only* intended for interactions with a DAPS and *nothing else*!"@en ;
     rdfs:seeAlso <https://tools.ietf.org/html/rfc7519> ;
     .
+    
+    
+ids:Audience
+    a owl:Class ;
+    rdfs:label "Audience"@en ;
+    rdfs:comment "The class of audiences (recipients) used in the JWT. "@en ;
+    rdfs:seeAlso <https://tools.ietf.org/html/rfc7519> ;
+    .
 
 
 # Properties
 # ----------
 
 
-ids:aud a owl:DatatypeProperty;
+ids:aud a owl:ObjectProperty;
     rdfs:label "aud"@en;
     rdfs:domain ids:JwtPayload;
-    rdfs:range xsd:string ;
+    rdfs:range ids:Audience ;
     rdfs:seeAlso <https://tools.ietf.org/html/rfc7519#section-4.1.3> ;
     rdfs:comment "The 'aud' (audience) claim identifies the recipients that the JWT is intended for."@en.
 

--- a/testing/security/TokenShape.ttl
+++ b/testing/security/TokenShape.ttl
@@ -118,7 +118,7 @@ shapes:JwtPayloadShape
     sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:scope ;
-		sh:datatype xsd:string ; 
+		sh:datatype xsd:string ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
 		sh:severity sh:Violation ;

--- a/testing/security/TokenShape.ttl
+++ b/testing/security/TokenShape.ttl
@@ -118,7 +118,7 @@ shapes:JwtPayloadShape
     sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:scope ;
-		sh:datatype xsd:string ;
+		sh:datatype xsd:string ; 
         sh:minCount 1 ;
         sh:maxCount 1 ;
 		sh:severity sh:Violation ;

--- a/testing/security/TokenShape.ttl
+++ b/testing/security/TokenShape.ttl
@@ -140,7 +140,7 @@ shapes:JwtPayloadShape
 		sh:path ids:extendedGuarantee ;
 		sh:class ids:SecurityGuarantee ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (JwtPayloadShape): The ids:extendedGuarantee property must point from an ids:JwtPayloadShape to an ids:SecurityGuarantee"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (JwtPayloadShape): The ids:extendedGuarantee property must point from an ids:JwtPayload to an ids:SecurityGuarantee"@en ; 
 	] ;
     
     sh:property [
@@ -148,7 +148,7 @@ shapes:JwtPayloadShape
         sh:path ids:transportCertsSha256 ;
         sh:datatype xsd:string ;
         sh:severity sh:Violation ;
-        sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (JwtPayloadShape): The ids:transportCertsSha256 property must point from an ids:JwtPayloadShape to a xsd:string "@en ; 
+        sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (JwtPayloadShape): The ids:transportCertsSha256 property must point from an ids:JwtPayload to a xsd:string "@en ; 
 	] ;
 .
 
@@ -164,7 +164,7 @@ shapes:DatPayloadShape
         sh:minCount 1 ;
         sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (JwtPayloadShape): Exactly one ids:iss property must point from ids:DatPayload to ids:Connector via an IRI."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (DatPayloadShape): Exactly one ids:iss property must point from ids:DatPayload to ids:Connector via an IRI."@en ; 
 	] ;
     
     sh:property [
@@ -174,6 +174,6 @@ shapes:DatPayloadShape
         sh:minCount 1 ;
         sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (JwtPayloadShape): Exactly one ids:iss property must point from an ids:JwtPayload to an xsd:string."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (DatPayloadShape): Exactly one ids:iss property must point from an ids:DatPayload to an xsd:string."@en ; 
 	] ;
 .

--- a/testing/security/TokenShape.ttl
+++ b/testing/security/TokenShape.ttl
@@ -40,21 +40,22 @@ shapes:TokenShape
 		sh:class ids:TokenFormat ;
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (TokenShape): An ids:tokenFormat property must point from an ids:Token to an ids:TokenFormat."@en ; 
-	] .
+	];
+.
 
 
-shapes:DatPayloadShape
+shapes:JwtPayloadShape
 	a sh:NodeShape ; 
-	sh:targetClass ids:DatPayload ;
+	sh:targetClass ids:JwtPayload  ;
 
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:aud  ;
-		sh:datatype xsd:string ;
+		sh:nodeKind sh:IRI ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (TokenShape): Exactly one ids:aud property must point from an ids:DatPayload to an xsd:string."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (JwtPayloadShape): Exactly one ids:aud property must point from an ids:JwtPayload to an ids:Audience via an IRI."@en ; 
 	] ;
 
 	sh:property [
@@ -64,7 +65,7 @@ shapes:DatPayloadShape
         sh:minCount 1 ;
         sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (TokenShape): Exactly one ids:exp property must point from an ids:DatPayload to an xsd:integer."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (JwtPayloadShape): Exactly one ids:exp property must point from an ids:JwtPayload to an xsd:integer."@en ; 
 	] ;
 
 	sh:property [
@@ -74,17 +75,15 @@ shapes:DatPayloadShape
         sh:minCount 1 ;
         sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (TokenShape): Exactly one ids:iat property must point from an ids:DatPayload to an xsd:integer."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (JwtPayloadShape): Exactly one ids:iat property must point from an ids:JwtPayload to an xsd:integer."@en ; 
 	] ;
 
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:iss  ;
 		sh:datatype xsd:string ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (TokenShape): Exactly one ids:iss property must point from an ids:DatPayload to an xsd:string."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (JwtPayloadShape): An ids:iss property must point from an ids:JwtPayload to an xsd:string."@en ; 
 	] ;
 
 	sh:property [
@@ -94,7 +93,7 @@ shapes:DatPayloadShape
         sh:minCount 1 ;
         sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (TokenShape): Exactly ids:nbf property must point from an ids:DatPayload to an xsd:integer."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (JwtPayloadShape): Exactly ids:nbf property must point from an ids:JwtPayload to an xsd:integer."@en ; 
 	] ;
 
 	sh:property [
@@ -102,10 +101,8 @@ shapes:DatPayloadShape
 		sh:path ids:referringConnector ;
 		sh:nodeKind sh:IRI ;
         #sh:class ids:Connector ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (TokenShape): Exactly one ids:referringConnector property must point from an ids:DatPayload to a Connector via an IRI."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (JwtPayloadShape): An ids:referringConnector property must point from an ids:JwtPayload to a Connector via an IRI."@en ; 
 	] ;
 
 	sh:property [
@@ -115,6 +112,68 @@ shapes:DatPayloadShape
         sh:minCount 1 ;
         sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (TokenShape): Exactly one ids:sub property must point from an ids:Token to an xsd:string."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (JwtPayloadShape): Exactly one ids:sub property must point from an ids:JwtPayload to an xsd:string."@en ; 
+	] ;
+    
+    sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:scope ;
+		sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+		sh:severity sh:Violation ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (JwtPayloadShape): Exactly one ids:sub property must point from an ids:JwtPayload to an xsd:string."@en ; 
+	] ;
+    
+    sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:securityProfile ;
+		sh:class ids:SecurityProfile ;
+		sh:minCount 1 ;
+		sh:maxCount 1 ;
+		sh:severity sh:Violation ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (JwtPayloadShape): An ids:JwtPayload must have exactly one ids:SecurityProfile linked through the ids:securityProfile property"@en ; 
+	] ;
+    
+    sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:extendedGuarantee ;
+		sh:class ids:SecurityGuarantee ;
+		sh:severity sh:Violation ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (JwtPayloadShape): The ids:extendedGuarantee property must point from an ids:JwtPayloadShape to an ids:SecurityGuarantee"@en ; 
+	] ;
+    
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path ids:transportCertsSha256 ;
+        sh:datatype xsd:string ;
+        sh:severity sh:Violation ;
+        sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (JwtPayloadShape): The ids:transportCertsSha256 property must point from an ids:JwtPayloadShape to a xsd:string "@en ; 
+	] ;
+.
+
+
+shapes:DatPayloadShape
+	a sh:NodeShape ; 
+	sh:targetClass ids:DatPayload  ;
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:referringConnector  ;
+		sh:nodeKind sh:IRI ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+		sh:severity sh:Violation ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (JwtPayloadShape): Exactly one ids:iss property must point from ids:DatPayload to ids:Connector via an IRI."@en ; 
+	] ;
+    
+    sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:iss  ;
+		sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+		sh:severity sh:Violation ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (JwtPayloadShape): Exactly one ids:iss property must point from an ids:JwtPayload to an xsd:string."@en ; 
 	] ;
 .


### PR DESCRIPTION
DAT did not reflect the explanations given in the Communication Guide. Introducing a new super class for JWTs, and a Request class for the DAT.

As the requester can not fill all attributes on its own, more optionals are set here. the final DAT is more restricitve.