### PR TITLE
#233 ids:Constraint validations

### DIFF
--- a/model/contract/Rule.ttl
+++ b/model/contract/Rule.ttl
@@ -61,13 +61,23 @@ ids:Constraint rdfs:subClassOf odrl:Constraint;
     rdfs:comment "The class of Constraints that restrict a Rule."@en;
     idsm:validation [
         idsm:forProperty ids:leftOperand;
-        idsm:constraint idsm:NotNull;
+        idsm:relationType idsm:OneToMany;
+        idsm:constraint idsm:NotEmpty;
     ] ;
     idsm:validation [
         idsm:forProperty ids:operator;
-        idsm:constraint idsm:NotNull;
+        idsm:relationType idsm:OneToMany;
+        idsm:constraint idsm:NotEmpty;
     ] ;
-    .
+    idsm:validation [
+        idsm:forProperty ids:rightOperand;
+        idsm:relationType idsm:OneToMany;
+    ] ;
+    idsm:validation [
+        idsm:forProperty ids:rightOperandReference;
+        idsm:relationType idsm:OneToMany;
+    ] ;
+.
 
 # Properties
 # ----------

--- a/model/contract/Rule.ttl
+++ b/model/contract/Rule.ttl
@@ -65,16 +65,7 @@ ids:Constraint rdfs:subClassOf odrl:Constraint;
     ] ;
     idsm:validation [
         idsm:forProperty ids:operator;
-        idsm:relationType idsm:OneToMany;
-        idsm:constraint idsm:NotEmpty;
-    ] ;
-    idsm:validation [
-        idsm:forProperty ids:rightOperand;
-        idsm:relationType idsm:OneToMany;
-    ] ;
-    idsm:validation [
-        idsm:forProperty ids:rightOperandReference;
-        idsm:relationType idsm:OneToMany;
+        idsm:constraint idsm:NotNull;
     ] ;
 .
 

--- a/model/contract/Rule.ttl
+++ b/model/contract/Rule.ttl
@@ -61,8 +61,7 @@ ids:Constraint rdfs:subClassOf odrl:Constraint;
     rdfs:comment "The class of Constraints that restrict a Rule."@en;
     idsm:validation [
         idsm:forProperty ids:leftOperand;
-        idsm:relationType idsm:OneToMany;
-        idsm:constraint idsm:NotEmpty;
+        idsm:constraint idsm:NotNull;
     ] ;
     idsm:validation [
         idsm:forProperty ids:operator;

--- a/model/contract/Rule.ttl
+++ b/model/contract/Rule.ttl
@@ -58,7 +58,16 @@ ids:Duty rdfs:subClassOf ids:Rule;
 ids:Constraint rdfs:subClassOf odrl:Constraint;
     a owl:Class;
     rdfs:label "Constraint"@en;
-    rdfs:comment "The class of Constraints that restrict a Rule."@en.
+    rdfs:comment "The class of Constraints that restrict a Rule."@en;
+    idsm:validation [
+        idsm:forProperty ids:leftOperand;
+        idsm:constraint idsm:NotNull;
+    ] ;
+    idsm:validation [
+        idsm:forProperty ids:operator;
+        idsm:constraint idsm:NotNull;
+    ] ;
+    .
 
 # Properties
 # ----------

--- a/testing/contract/RuleShape.ttl
+++ b/testing/contract/RuleShape.ttl
@@ -143,7 +143,7 @@ shapes:ConstraintShape
     ]
     [
         sh:path ids:rightOperandReference ;
-        sh:datatype rdfs:Resource ;
+        sh:class rdfs:Resource ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:severity sh:Violation ;

--- a/testing/contract/RuleShape.ttl
+++ b/testing/contract/RuleShape.ttl
@@ -130,14 +130,22 @@ shapes:ConstraintShape
 		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/RuleShape.ttl> (ConstraintShape): An ids:Constraint must have at least one ids:BinaryOperator linked through the ids:operator property"@en ; 
 	] ;
 
-	sh:property [
-		a sh:PropertyShape ;
-		sh:path ids:rightOperand ;
-		sh:datatype rdfs:Literal ;
-		sh:minCount 1 ;
-		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/RuleShape.ttl> (ConstraintShape): An ids:Constraint must have at least one rdfs:Literal linked through the ids:rightOperand property"@en ; 
-	] ;
+	sh:xone (
+    [
+	    sh:path ids:rightOperand ;
+	    sh:datatype rdfs:Literal ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/RuleShape.ttl> (ConstraintShape): An ids:Constraint must have at least one rdfs:Literal linked through the ids:rightOperand or least one rdfs:Resource linked through the ids:rightOperandReference property."@en ; 
+    ]
+    [
+        sh:path ids:rightOperandReference ;
+        sh:datatype rdfs:Resource ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/RuleShape.ttl> (ConstraintShape): An ids:Constraint must have at least one rdfs:Literal linked through the ids:rightOperand property or least one rdfs:Resource linked through the ids:rightOperandReference property."@en ; 
+    ]
+	) ;
 
 	sh:property [
 		a sh:PropertyShape ;

--- a/testing/contract/RuleShape.ttl
+++ b/testing/contract/RuleShape.ttl
@@ -155,6 +155,7 @@ shapes:ConstraintShape
 		a sh:PropertyShape ;
 		sh:path ids:unit ;
 		sh:class ids:Unit ;
+        sh:maxCount 1 ;
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/RuleShape.ttl> (ConstraintShape): An ids:unit property must point from an ids:Constraint to an ids:Unit."@en ; 
 	] .

--- a/testing/contract/RuleShape.ttl
+++ b/testing/contract/RuleShape.ttl
@@ -117,6 +117,7 @@ shapes:ConstraintShape
 		sh:path ids:leftOperand ;
 		sh:class ids:LeftOperand ;
 		sh:minCount 1 ;
+        sh:maxCount 1 ;
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/RuleShape.ttl> (ConstraintShape): An ids:Constraint must have at least one ids:LeftOperand linked through the ids:leftOperand property"@en ; 
 	] ;

--- a/testing/contract/RuleShape.ttl
+++ b/testing/contract/RuleShape.ttl
@@ -119,7 +119,7 @@ shapes:ConstraintShape
 		sh:minCount 1 ;
         sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/RuleShape.ttl> (ConstraintShape): An ids:Constraint must have at least one ids:LeftOperand linked through the ids:leftOperand property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/RuleShape.ttl> (ConstraintShape): An ids:Constraint must have  exactly one ids:LeftOperand linked through the ids:leftOperand property"@en ; 
 	] ;
 
 	sh:property [
@@ -127,8 +127,9 @@ shapes:ConstraintShape
 		sh:path ids:operator ;
 		sh:class ids:BinaryOperator ;
 		sh:minCount 1 ;
+        sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/RuleShape.ttl> (ConstraintShape): An ids:Constraint must have at least one ids:BinaryOperator linked through the ids:operator property"@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/RuleShape.ttl> (ConstraintShape): An ids:Constraint must have  exactly one ids:BinaryOperator linked through the ids:operator property"@en ; 
 	] ;
 
 	sh:xone (
@@ -136,15 +137,17 @@ shapes:ConstraintShape
 	    sh:path ids:rightOperand ;
 	    sh:datatype rdfs:Literal ;
         sh:minCount 1 ;
+        sh:maxCount 1 ;
         sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/RuleShape.ttl> (ConstraintShape): An ids:Constraint must have at least one rdfs:Literal linked through the ids:rightOperand or least one rdfs:Resource linked through the ids:rightOperandReference property."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/RuleShape.ttl> (ConstraintShape): An ids:Constraint must have exactly one rdfs:Literal linked through the ids:rightOperand or least one rdfs:Resource linked through the ids:rightOperandReference property."@en ; 
     ]
     [
         sh:path ids:rightOperandReference ;
         sh:datatype rdfs:Resource ;
         sh:minCount 1 ;
+        sh:maxCount 1 ;
         sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/RuleShape.ttl> (ConstraintShape): An ids:Constraint must have at least one rdfs:Literal linked through the ids:rightOperand property or least one rdfs:Resource linked through the ids:rightOperandReference property."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/contract/RuleShape.ttl> (ConstraintShape): An ids:Constraint must have exactly one rdfs:Literal linked through the ids:rightOperand property or least one rdfs:Resource linked through the ids:rightOperandReference property."@en ; 
     ]
 	) ;
 


### PR DESCRIPTION
Closes #233

Changes:
- add idsm annotations for ids:Constraint
- make _ids:rightOperandReference_ an alternative for _ids:rightOperand_ in SHACL shape


Note:
- rightOperand & rightOperandReference can not be modelled with in XOR relation in our Information Model, like I did in SHACL. 