### PR TITLE
fix extendedguarantee domain

### DIFF
--- a/model/infrastructure/Connector.ttl
+++ b/model/infrastructure/Connector.ttl
@@ -78,7 +78,7 @@ ids:securityProfile a owl:ObjectProperty;
     
 ids:extendedGuarantee a owl:ObjectProperty;
     rdfs:domain [ rdf:type owl:Class ;
-                owl:unionOf ( ids:Connector ids:JwtPayload)
+                owl:unionOf ( ids:Connector ids:DatPayload)
               ] ;
     rdfs:range ids:SecurityGuarantee;
     rdfs:label "extended guarantee"@en;

--- a/model/security/Token.ttl
+++ b/model/security/Token.ttl
@@ -70,10 +70,6 @@ ids:JwtPayload a owl:Class ;
         idsm:constraint idsm:NotNull;
     ];
     idsm:validation [
-        idsm:forProperty ids:extendedGuarantee;
-        idsm:relationType idsm:OneToMany;
-    ];
-    idsm:validation [
         idsm:forProperty ids:transportCertsSha256;
         idsm:relationType idsm:OneToMany;
     ]; 
@@ -95,6 +91,10 @@ ids:DatPayload
         idsm:forProperty ids:iss;
         idsm:constraint idsm:NotNull;
     ] ;
+    idsm:validation [
+        idsm:forProperty ids:extendedGuarantee;
+        idsm:relationType idsm:OneToMany;
+    ]
 .
 
 

--- a/testing/security/TokenShape.ttl
+++ b/testing/security/TokenShape.ttl
@@ -136,14 +136,6 @@ shapes:JwtPayloadShape
 	] ;
     
     sh:property [
-		a sh:PropertyShape ;
-		sh:path ids:extendedGuarantee ;
-		sh:class ids:SecurityGuarantee ;
-		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (JwtPayloadShape): The ids:extendedGuarantee property must point from an ids:JwtPayload to an ids:SecurityGuarantee"@en ; 
-	] ;
-    
-    sh:property [
         a sh:PropertyShape ;
         sh:path ids:transportCertsSha256 ;
         sh:datatype xsd:string ;
@@ -175,5 +167,13 @@ shapes:DatPayloadShape
         sh:maxCount 1 ;
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (DatPayloadShape): Exactly one ids:iss property must point from an ids:DatPayload to an xsd:string."@en ; 
+	] ;
+    
+    sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:extendedGuarantee ;
+		sh:class ids:SecurityGuarantee ;
+		sh:severity sh:Violation ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/security/TokenShape.ttl> (DatPayloadShape): The ids:extendedGuarantee property must point from an ids:DatPayload to an ids:SecurityGuarantee"@en ; 
 	] ;
 .


### PR DESCRIPTION
As discussed with the Fraunhofer AISEC colleagues and @sebbader :

A RequestToken for the DAPS should not contain the extendedGuarantee claims of a Connector. A signed DAPS token can hold such guarantees and claims.

Fix rdfs:domain, idsm:constraints and SHACL shapes for  `ids:extendedGuarantee`
