### PR TITLE
fixed versionIRI

### DIFF
--- a/create-ontology-ttl.sh
+++ b/create-ontology-ttl.sh
@@ -58,7 +58,7 @@ ids:
     dct:created "2017-09-26"^^xsd:date ;
     dct:modified "$(date +%Y-%m-%d)"^^xsd:date ;
     owl:versionInfo "${version}" ;
-    owl:versionIRI <https://w3id.org/idsa/core/${version}>" ;
+    owl:versionIRI <https://w3id.org/idsa/core/${version}> ;
     vann:preferredNamespaceUri "https://w3id.org/idsa/core/" ;
     vann:preferredNamespacePrefix "ids" ;
     rdfs:seeAlso <https://industrialdataspace.github.io/InformationModel/> ;

--- a/create-ontology-ttl.sh
+++ b/create-ontology-ttl.sh
@@ -52,7 +52,7 @@ write_to_file()
 	echo '    dct:created "2017-09-26"^^xsd:date;' >> "$file"
 	echo '    dct:modified "'$(date +%Y-%m-%d)'"^^xsd:date;' >> "$file"
 	echo '    owl:versionInfo "'$version'";' >> "$file"
-	echo '    owl:versionIRI "https://w3id.org/idsa/core/'$version'>";' >> "$file"
+	echo '    owl:versionIRI <https://w3id.org/idsa/core/'$version'> ;' >> "$file"
 	echo '    vann:preferredNamespaceUri "https://w3id.org/idsa/core/";' >> "$file"
 	echo '    vann:preferredNamespacePrefix "ids" ;' >> "$file"
 	echo '    rdfs:seeAlso <https://industrialdataspace.github.io/InformationModel/> ;' >> "$file"


### PR DESCRIPTION
Even though some examples are around that use a literal object with owl:versionIRI, a URI object is the standard