### PR TITLE
affectedResource should only reference a Resource in header

### DIFF
--- a/taxonomies/Message.ttl
+++ b/taxonomies/Message.ttl
@@ -321,6 +321,7 @@ ids:ResourceUnavailableMessage a owl:Class ;
     rdfs:comment "Message indicating that a specific resource is unavailable."@en.
 
 ids:affectedResource rdf:type owl:ObjectProperty ;
+    idsm:referenceByUri true;
     rdfs:domain ids:ResourceNotificationMessage;
     rdfs:range ids:Resource ;
     rdfs:label "affected Resource"@en ;


### PR DESCRIPTION
Same as for affectedConnector and affectedParticipant - the affectedResource should only be referenced and not printed in its entirety inside the header. Otherwise, we will end up delivering it twice - once in the header, once in the payload.