### PR TITLE
Feature/language addons

### DIFF
--- a/codes/Language.ttl
+++ b/codes/Language.ttl
@@ -11,7 +11,7 @@
 
 idsc:MULTI_LINGUAL
     a ids:Language ;
-    rdfs:label "multilingual"@en ;
+    rdfs:label "Multilingual"@en ;
     rdfs:comment "Code indicates that several languages are used or no concrete language can be determined.";
     .
 

--- a/codes/Language.ttl
+++ b/codes/Language.ttl
@@ -9,6 +9,11 @@
 # Instance names are equaivalent to the corresponding ISO-639-1 language code. 
 # -------------------------------
 
+idsc:MULTI_LINGUAL
+    a ids:Language ;
+    rdfs:label "multilingual"@en ;
+    rdfs:comment "Code indicates that several languages are used or no concrete language can be determined.";
+    .
 
 idsc:AB
     a ids:Language ;

--- a/model/content/DigitalContent.ttl
+++ b/model/content/DigitalContent.ttl
@@ -96,7 +96,9 @@ ids:defaultRepresentation
 ids:language
     a owl:ObjectProperty;
     rdfs:subPropertyOf dct:language;
-    rdfs:domain ids:DigitalContent;
+    rdfs:domain [ rdf:type owl:Class ;
+                owl:unionOf ( ids:DigitalContent ids:Representation)
+              ] ;
     rdfs:range ids:Language; # does not fit the defined range of dct:language - dct:LinguisticSystem !
     rdfs:label "language"@en;
     rdfs:comment "Natural language(s) used within the content."@en.

--- a/testing/content/RepresentationShape.ttl
+++ b/testing/content/RepresentationShape.ttl
@@ -57,7 +57,7 @@ shapes:RepresentationShape
 		sh:datatype xsd:dateTimeStamp ;
         sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/RepresentationShape.ttl> (RepresentationShape): An ids:DigitalContent must have at most one ids:created attribute pointing to a valid xsd:dateTimeStamp."@en ; 
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/RepresentationShape.ttl> (RepresentationShape): An ids:Representation must have at most one ids:created attribute pointing to a valid xsd:dateTimeStamp."@en ; 
 	] ;
 
 	sh:property [
@@ -67,6 +67,14 @@ shapes:RepresentationShape
 		sh:datatype xsd:dateTimeStamp ;
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/RepresentationShape.ttl> (RepresentationShape):An ids:Representation must have at most one ids:modified attribute pointing to a valid xsd:dateTimeStamp."@en ; 
+	] ;
+    
+    sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:language ;
+		sh:class ids:Language ;
+		sh:severity sh:Violation ;
+		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/content/RepresentationShape.ttl> (RepresentationShape): An ids:language property must point from an ids:Representation to an ids:Language."@en ; 
 	] ;
 .
 


### PR DESCRIPTION
As previously discussed, we have encountered following problems:
- ids:Resources with a variety of languages cannot be labelled properly. 
- It would be useful to have a way to add languages for ids:Representations of an ids:Resource.

I added a code for "multilingual" and ids:Representation as a domain of the `ìds:language` property. 