### PR TITLE
Feature/par is catalog

### DIFF
--- a/model/infrastructure/Catalog.ttl
+++ b/model/infrastructure/Catalog.ttl
@@ -12,29 +12,57 @@
 ids:Catalog
     rdfs:subClassOf dcat:Catalog;
     a owl:Class;
+    idsm:abstract true;
     rdfs:label "Catalog"@en ;
+    rdfs:comment "Class that represents (distributable) Catalogs."@en ;
+    .
+
+ids:ResourceCatalog
+    rdfs:subClassOf ids:Catalog;
+    a owl:Class;
+    rdfs:label "Resource Catalog"@en ;
     rdfs:comment "Class that aggregates Resources which, as a whole, form a (distributable) Catalog."@en ;
     idsm:validation [
-        idsm:forProperty ids:request;
+        idsm:forProperty ids:requestedResources;
         idsm:relationType idsm:OneToMany;
     ];
     idsm:validation [
-        idsm:forProperty ids:offer;
+        idsm:forProperty ids:offeredResources;
         idsm:relationType idsm:OneToMany;
-    ].
+    ];
+.
+
+ids:ParticipantCatalog
+    rdfs:subClassOf ids:Catalog;
+    a owl:Class;
+    rdfs:label "Participant Catalog"@en ;
+    rdfs:comment "Class that aggregates Participants which, as a whole, from a (distributable) Catalog."@en ;
+    idsm:validation [
+        idsm:forProperty ids:members;
+        idsm:relationType idsm:OneToMany;
+    ];
+.
 
 # Properties
 # ----------
 
-ids:offer a owl:ObjectProperty;
-    rdfs:domain ids:Catalog;
+ids:offeredResources a owl:ObjectProperty;
+    rdfs:subPropertyOf dcat:dataset;
+    rdfs:domain ids:ResourceCatalog;
     rdfs:range ids:Resource;
-    rdfs:label "offer"@en;
-    rdfs:comment "A Resource that is part of a Connector, indicating a offering (of, e.g., data)."@en.
+    rdfs:label "offered resources"@en;
+    rdfs:comment "A resource that is part of a resource catalog, indicating an offering (of, e.g., data)."@en.
 
-ids:request a owl:ObjectProperty;
-    rdfs:domain ids:Catalog;
+ids:requestedResources a owl:ObjectProperty;
+    rdfs:subPropertyOf dcat:dataset;
+    rdfs:domain ids:ResourceCatalog;
     rdfs:range ids:Resource;
     rdfs:label "request"@en;
-    rdfs:comment "A Resource that is part of a Connector, indicating a request (of, e.g., data, software,...)."@en.
+    rdfs:comment "A resource that is part of a resource catalog, indicating a request (of, e.g., data, software,...)."@en.
 
+ids:members a owl:ObjectProperty;
+    rdfs:subPropertyOf dcat:dataset;
+    rdfs:domain ids:ParticipantCatalog;
+    rdfs:range ids:Participant;
+    rdfs:label "offer"@en;
+    rdfs:comment "A Participant, that is part of a participant catalog."@en.

--- a/model/infrastructure/Connector.ttl
+++ b/model/infrastructure/Connector.ttl
@@ -114,9 +114,9 @@ ids:authInfo a owl:ObjectProperty;
     rdfs:label "authInfo"@en;
     rdfs:comment "Information of the authentication service used by the Connector."@en.
 
-ids:catalog a owl:ObjectProperty;
+ids:resourceCatalog a owl:ObjectProperty;
     rdfs:domain ids:Connector;
-    rdfs:range ids:Catalog;
+    rdfs:range ids:ResourceCatalog;
     rdfs:label "catalog"@en;
     rdfs:comment "References the Catalog of published or requested resource by this Connector."@en.
 

--- a/model/infrastructure/Connector.ttl
+++ b/model/infrastructure/Connector.ttl
@@ -117,7 +117,7 @@ ids:authInfo a owl:ObjectProperty;
 ids:resourceCatalog a owl:ObjectProperty;
     rdfs:domain ids:Connector;
     rdfs:range ids:ResourceCatalog;
-    rdfs:label "catalog"@en;
+    rdfs:label "resource catalog"@en;
     rdfs:comment "References the Catalog of published or requested resource by this Connector."@en.
 
 ids:hasAgents a owl:ObjectProperty;

--- a/model/infrastructure/Connector.ttl
+++ b/model/infrastructure/Connector.ttl
@@ -120,7 +120,7 @@ ids:resourceCatalog a owl:ObjectProperty;
     rdfs:label "catalog"@en;
     rdfs:comment "References the Catalog of published or requested resource by this Connector."@en.
 
-ids:hasAgent a owl:ObjectProperty;
+ids:hasAgents a owl:ObjectProperty;
     idsm:referenceByUri true;
     rdfs:label "has Agent"@en;
     rdfs:domain ids:Connector;

--- a/model/infrastructure/ParIS.ttl
+++ b/model/infrastructure/ParIS.ttl
@@ -12,4 +12,12 @@ ids:ParIS
     rdfs:subClassOf ids:Connector;
     rdfs:label "Participant Information Service"@en ;
     rdfs:comment "The Participant Information Service (ParIS) provides metadata and relevant information about participants (humans and organizations) in the International Data Spaces."@en .
+    
 
+ids:participantCatalog
+    a owl:ObjectProperty;
+    rdfs:domain ids:ParIS;
+    rdfs:range ids:ParticipantCatalog;
+    rdfs:label "participant catalog"@en ;
+    rdfs:comment "List of participants a ParIS may expose."@en ;
+    .

--- a/testing/infrastructure/CatalogShape.ttl
+++ b/testing/infrastructure/CatalogShape.ttl
@@ -25,19 +25,50 @@ shapes:CatalogShape
 	a sh:NodeShape ; 
 	sh:targetClass ids:Catalog ;
 
+    sh:sparql [
+		a sh:SPARQLConstraint ;
+		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/infrastructure/CatalogShape.ttl> (CatalogShape): An ids:Catalog is an abstract class. Please use one of the subclasses for the generation of instances."@en ;
+		sh:prefixes shapes: ;
+		sh:select """
+			SELECT ?this ?type
+			WHERE {
+				?this rdf:type ?type .
+				FILTER (?type = ids:Catalog)
+			}
+		""" ;
+	] ;
+.
+
+
+shapes:ResourceCatalogShape
+	a sh:NodeShape ; 
+	sh:targetClass ids:ResourceCatalog ;
 	sh:property [
 		a sh:PropertyShape ;
-		sh:path ids:offer ;
+		sh:path ids:offeredResources ;
 		sh:class ids:Resource ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/infrastructure/CatalogShape.ttl> (CatalogShape): An ids:offer property must point from an ids:Catalog to an ids:Resource."@en ;
+		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/infrastructure/CatalogShape.ttl> (ResourceCatalog): An ids:offeredResources property must point from an ids:ResourceCatalog to an ids:Resource."@en ;
 	] ;
 
 	sh:property [
 		a sh:PropertyShape ;
-		sh:path ids:request ;
+		sh:path ids:requestedResources ;
 		sh:class ids:Resource ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/infrastructure/CatalogShape.ttl> (CatalogShape): An ids:request property must point from an ids:Catalog to an ids:Resource."@en ;
-	] .
+		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/infrastructure/CatalogShape.ttl> (ResourceCatalog): An ids:requestedResources property must point from an ids:ResourceCatalog to an ids:Resource."@en ;
+	] ;
+.
 
+
+shapes:ParticipantCatalogShape
+	a sh:NodeShape ; 
+	sh:targetClass ids:ParticipantCatalog ;
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:members ;
+		sh:class ids:Participant ;
+		sh:severity sh:Violation ;
+		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/infrastructure/CatalogShape.ttl> (ParticipantCatalog): An ids:members property must point from an ids:ParticipantCatalog to an ids:Participant."@en ;
+	] ;
+.

--- a/testing/infrastructure/ConnectorShape.ttl
+++ b/testing/infrastructure/ConnectorShape.ttl
@@ -101,12 +101,12 @@ shapes:ConnectorShape
 
 	sh:property [
 		a sh:PropertyShape ;
-		sh:path ids:catalog ;
-		sh:class ids:Catalog ;
-		sh:minCount 1 ;
-		sh:maxCount 1 ;
+		sh:path ids:resourceCatalog ;
+		sh:class ids:ResourceCatalog ;
+		#sh:minCount 1 ;
+		#sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/infrastructure/ConnectorShape.ttl> (ConnectorShape): An ids:Connector must have exactly one ids:Catalog linked through the ids:catalog property"@en ;
+		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/infrastructure/ConnectorShape.ttl> (ConnectorShape): An ids:Connector must point to an  ids:ResourceCatalog via the ids:resourceCatalog property."@en ;
 	] ;
 
 	sh:property [

--- a/testing/infrastructure/ParISSHape.ttl
+++ b/testing/infrastructure/ParISSHape.ttl
@@ -1,0 +1,35 @@
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ids: <https://w3id.org/idsa/core/> .
+@prefix idsm: <https://w3id.org/idsa/metamodel/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix shapes: <https://github.com/International-Data-Spaces-Association/InformationModel/tree/master/testing> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+shapes:
+	a owl:Ontology ;
+	sh:declare [
+		sh:prefix "rdf" ;
+		sh:namespace "http://www.w3.org/1999/02/22-rdf-syntax-ns#"^^xsd:anyURI ;
+	] ;
+
+	sh:declare [
+		sh:prefix "ids" ;
+		sh:namespace "https://w3id.org/idsa/core/"^^xsd:anyURI ;
+	] .
+
+
+shapes:ParISShape
+	a sh:NodeShape ; 
+	sh:targetClass ids:ParIS ;
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:participantCatalog ;
+		sh:class ids:ParticipantCatalog ;
+		sh:severity sh:Violation ;
+		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/infrastructure/ParISShape.ttl> (ParISShape): An ids:participantCatalog property must point from an ids:ParIS to an ids:ParticipantCatalog."@en ;
+	];
+.
+


### PR DESCRIPTION
Redesign of catalogs:
- ids:Catalog is now abstract superclass for specific catalogs. 
- New classes `ids:ResourceCatalog` and `ids:ParticipantCatalog`, which hold ids:Resource respectively ids:Participant information, which can be used inside Connectors and ParIS. 
- Connectors now refer to `ids:ResourceCatalog` 
- ParIS now has its own catalog for participants, the `ids:ParticipantCatalog` 


Resolves #287

