### PR TITLE
More catalogs

### DIFF
--- a/model/infrastructure/Broker.ttl
+++ b/model/infrastructure/Broker.ttl
@@ -12,6 +12,10 @@ ids:Broker
     rdfs:subClassOf ids:Connector;
     rdfs:label "Broker"@en ;
     rdfs:comment "Broker holding an index of published data endpoints."@en;
+    idsm:validation [
+        idsm:forProperty ids:connectorCatalog;
+        idsm:relationType idsm:OneToMany;
+    ];
     .
 
 ids:connectorCatalog a owl:ObjectProperty;

--- a/model/infrastructure/Broker.ttl
+++ b/model/infrastructure/Broker.ttl
@@ -12,15 +12,11 @@ ids:Broker
     rdfs:subClassOf ids:Connector;
     rdfs:label "Broker"@en ;
     rdfs:comment "Broker holding an index of published data endpoints."@en;
-    idsm:validation [
-        idsm:forProperty ids:connector;
-        idsm:relationType idsm:OneToMany;
-    ].
+    .
 
-ids:connector a owl:ObjectProperty;
-    idsm:referenceByUri true;
-    rdfs:label "connector"@en;
+ids:connectorCatalog a owl:ObjectProperty;
+    rdfs:label "connector Catalog"@en;
     rdfs:domain ids:Broker;
-    rdfs:range ids:Connector;
-    rdfs:comment "Reference to a Connector listed in the Broker."@en.
+    rdfs:range ids:ConnectorCatalog;
+    rdfs:comment "Reference to catalog of Connectors, which are listed in the Broker."@en.
 

--- a/model/infrastructure/Catalog.ttl
+++ b/model/infrastructure/Catalog.ttl
@@ -43,6 +43,17 @@ ids:ParticipantCatalog
     ];
 .
 
+ids:ConnectorCatalog
+    rdfs:subClassOf ids:Catalog;
+    a owl:Class;
+    rdfs:label "Connector Catalog"@en ;
+    rdfs:comment "Class that aggregates Connectors which, as a whole, from a (distributable) Catalog."@en ;
+    idsm:validation [
+        idsm:forProperty ids:listedConnector;
+        idsm:relationType idsm:OneToMany;
+    ];
+.
+
 # Properties
 # ----------
 
@@ -66,3 +77,12 @@ ids:members a owl:ObjectProperty;
     rdfs:range ids:Participant;
     rdfs:label "offer"@en;
     rdfs:comment "A Participant, that is part of a participant catalog."@en.
+
+ids:listedConnector a owl:ObjectProperty;
+    rdfs:subPropertyOf dcat:dataset;
+    rdfs:domain ids:ConnectorCatalog;
+    rdfs:range ids:Connector;
+    rdfs:label "listed Connector"@en;
+    rdfs:comment "A Connector, that is part of a Connector catalog."@en;
+.
+

--- a/model/infrastructure/Connector.ttl
+++ b/model/infrastructure/Connector.ttl
@@ -39,7 +39,12 @@ ids:Connector
     idsm:validation [
         idsm:forProperty ids:hasAgent;
         idsm:relationType idsm:OneToMany;
-    ].
+    ];
+    idsm:validation [
+        idsm:forProperty ids:resourceCatalog;
+        idsm:relationType idsm:OneToMany;
+    ]
+    .
 
 ids:BaseConnector rdfs:subClassOf ids:Connector ;
     a owl:Class;
@@ -97,7 +102,7 @@ ids:resourceCatalog a owl:ObjectProperty;
     rdfs:label "resource catalog"@en;
     rdfs:comment "References the Catalog of published or requested resource by this Connector."@en.
 
-ids:hasAgents a owl:ObjectProperty;
+ids:hasAgent a owl:ObjectProperty;
     idsm:referenceByUri true;
     rdfs:label "has Agent"@en;
     rdfs:domain ids:Connector;

--- a/model/infrastructure/ParIS.ttl
+++ b/model/infrastructure/ParIS.ttl
@@ -11,7 +11,12 @@ ids:ParIS
     a owl:Class;
     rdfs:subClassOf ids:Connector;
     rdfs:label "Participant Information Service"@en ;
-    rdfs:comment "The Participant Information Service (ParIS) provides metadata and relevant information about participants (humans and organizations) in the International Data Spaces."@en .
+    rdfs:comment "The Participant Information Service (ParIS) provides metadata and relevant information about participants (humans and organizations) in the International Data Spaces."@en ;
+    idsm:validation [
+        idsm:forProperty ids:participantCatalog;
+        idsm:relationType idsm:OneToMany;
+    ];
+    .
     
 
 ids:participantCatalog

--- a/testing/infrastructure/BrokerShape.ttl
+++ b/testing/infrastructure/BrokerShape.ttl
@@ -26,10 +26,9 @@ shapes:BrokerShape
 
 	sh:property [
 		a sh:PropertyShape ;
-		sh:path ids:connector ;
-		# sh:class ids:Connector ; # A property with `idsm:referenceByUri true` must not have a class check
-		sh:nodeKind sh:IRI ;
+		sh:path ids:connectorCatalog ;
+		sh:class ids:ConnectorCatalog;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/infrastructure/BrokerShape.ttl> (BrokerShape): An ids:connector property must point from an ids:Broker to an ids:Connector."@en ;
+		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/infrastructure/BrokerShape.ttl> (BrokerShape): An ids:connectorCatalog property must point from an ids:Broker to an ids:ConnectorCatalog."@en ;
 	] .
 

--- a/testing/infrastructure/CatalogShape.ttl
+++ b/testing/infrastructure/CatalogShape.ttl
@@ -72,3 +72,16 @@ shapes:ParticipantCatalogShape
 		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/infrastructure/CatalogShape.ttl> (ParticipantCatalog): An ids:members property must point from an ids:ParticipantCatalog to an ids:Participant."@en ;
 	] ;
 .
+
+
+shapes:ConnectorCatalogShape
+	a sh:NodeShape ; 
+	sh:targetClass ids:ConnectorCatalog ;
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:listedConnector ;
+		sh:class ids:Connector ;
+		sh:severity sh:Violation ;
+		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/infrastructure/CatalogShape.ttl> (ConnectorCatalog): An ids:listedConnector property must point from an ids:ConnectorCatalog to an ids:Connector."@en ;
+	] ;
+.


### PR DESCRIPTION
As part of the simplifications (see #310 ) , we also did some cleanup for existing structures.
Since ParIS and Connectors have Catalogs for its contents (ParticipantCatalog / ResourceCatalog), the broker should have the same capabilities. 

Additionally, Connectors should be able to present multiple Catalogs.
