### PR TITLE
Remove alternative xsd:date for both ids:modified and ids:created, and its shapes

### DIFF
--- a/model/content/DigitalContent.ttl
+++ b/model/content/DigitalContent.ttl
@@ -169,7 +169,7 @@ ids:created
     rdfs:domain [ rdf:type owl:Class ;
                 owl:unionOf ( ids:DigitalContent ids:Representation)
               ] ;
-    rdfs:range xsd:dateTimeStamp, xsd:date ;
+    rdfs:range xsd:dateTimeStamp;
     rdfs:label "created"@en;
     rdfs:seeAlso dct:created ;
     rdfs:comment "The date of the creation of the Digital Content. In contrast to the ids:temporalCoverage, creation dates of ids:Representation, ids:Artifacts or any other form of meta-data, this property describes the creation date of referenced Digital Content itself."@en.
@@ -180,7 +180,7 @@ ids:modified
     rdfs:domain [ rdf:type owl:Class ;
                 owl:unionOf ( ids:DigitalContent ids:Representation)
               ] ;
-    rdfs:range xsd:dateTimeStamp, xsd:date;
+    rdfs:range xsd:dateTimeStamp;
     rdfs:label "modified"@en;
     rdfs:seeAlso dct:modified ;
     rdfs:comment "The date/time this Digital Content has been changed the last time. Only one 'modified' attribute is usually needed."@en.

--- a/testing/content/DigitalContentShape.ttl
+++ b/testing/content/DigitalContentShape.ttl
@@ -137,10 +137,7 @@ shapes:DigitalContentShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:created ;
-		sh:or (
-			[sh:datatype  xsd:dateTimeStamp]
-			[sh:datatype xsd:date]
-		) ;
+		sh:datatype  xsd:dateTimeStamp ;
     sh:maxCount 1 ;
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/content/DigitalContentShape.ttl> (DigitalContentShape): An ids:DigitalContentShape must have at most one ids:created attribute pointing to a valid xsd:dateTimeStamp or xsd:date."@en ;
@@ -150,10 +147,7 @@ shapes:DigitalContentShape
 		a sh:PropertyShape ;
 		sh:path ids:modified ;
     sh:maxCount 1 ;
-		sh:or (
-						[sh:datatype  xsd:dateTimeStamp]
-						[sh:datatype xsd:date]
-					) ;
+		sh:datatype  xsd:dateTimeStamp ;
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/content/DigitalContentShape.ttl> (DigitalContentShape): An ids:DigitalContentShape must have at most one ids:modified attribute pointing to a valid xsd:dateTimeStamp or xsd:date."@en ;
 	] ;


### PR DESCRIPTION
Since the Java tooling does not support multiple ranges, we removed the second option `dct:date` from both `ids:created` and `ids:modified`. They now have one range only, which is `dct:dateTimeStamp`