### PR TITLE
Wrong idsm:annotation fixed

### DIFF
--- a/model/content/DataApp.ttl
+++ b/model/content/DataApp.ttl
@@ -16,11 +16,8 @@ ids:DataApp
     idsm:validation [
                         idsm:forProperty ids:appEndpoint;
                         idsm:relationType idsm:OneToMany ;
-                    ];
-    idsm:validation [
-                        idsm:forProperty ids:appEndpoint;
                         idsm:constraint idsm:NotEmpty;
-                    ]
+                    ];
 .
 ids:appDocumentation
     a owl:DatatypeProperty ;

--- a/model/content/DataApp.ttl
+++ b/model/content/DataApp.ttl
@@ -19,7 +19,7 @@ ids:DataApp
                     ];
     idsm:validation [
                         idsm:forProperty ids:appEndpoint;
-                        idsm:constraint idsm:NotNull;
+                        idsm:constraint idsm:NotEmpty;
                     ]
 .
 ids:appDocumentation


### PR DESCRIPTION
For a cardinality restriction of 1..n, it is required to add "OneToMany" (was present) and "NotEmpty" (was "NotNull")