### PR TITLE
Update CONTRACT_MESSAGES.ttl

### DIFF
--- a/examples/CONTRACT_MESSAGES.ttl
+++ b/examples/CONTRACT_MESSAGES.ttl
@@ -19,8 +19,7 @@ conn3:inter3_r a ids:ContractRequestMessage;
 		ids:tokenFormat idsc:JWT ;
 		ids:tokenValue "Some token goes here"^^xsd:string ;
 	];
-	ids:senderAgent conn3:senderAgent ;
-    ids:baseContractOffer data1:offer;
+    ids:senderAgent conn3:senderAgent ;
 .
 
 # counteroffer from providing connector as part of the payload


### PR DESCRIPTION
ids:baseContractOffer was removed way back in 2.0.1, see https://github.com/International-Data-Spaces-Association/InformationModel/blob/develop/CHANGELOG.md#changed-2