### PR TITLE
fix range for ids:constraint property

### DIFF
--- a/model/contract/Rule.ttl
+++ b/model/contract/Rule.ttl
@@ -107,7 +107,7 @@ ids:constraint rdfs:subPropertyOf odrl:constraint;
     a owl:ObjectProperty;
     rdfs:label "constraint"@en;
     rdfs:domain ids:Rule;
-    rdfs:range ids:Constraint;
+    rdfs:range ids:AbstractConstraint;
     rdfs:comment "The constraint to be used for a specific rule."@en.
 
 ids:assetRefinement


### PR DESCRIPTION
There is a small mistake in our modeling.

In the ids:Rule class, the `ids:constraint` property points to `ids:Contraint`.
The corresponding Rule Shape indicates that we should refer to the superclass of ids:Constraint.  In the current implementation, we can not refer to LogicalConstraints from rules.
https://github.com/International-Data-Spaces-Association/InformationModel/blob/54146ee8097fe12a45b4ec4bffe501765d96284d/testing/contract/RuleShape.ttl#L88-L94