### PR TITLE
password fields for trust/key store

### DIFF
--- a/model/infrastructure/ConfigurationModel.ttl
+++ b/model/infrastructure/ConfigurationModel.ttl
@@ -87,11 +87,25 @@ ids:trustStore a owl:DatatypeProperty;
     rdfs:comment "URI of the trust store server."@en ;
 .
 
+ids:trustStorePassword a owl:DatatypeProperty;
+    rdfs:domain ids:ConfigurationModel;
+    rdfs:range xsd:string;
+    rdfs:label "trust store password"@en ;
+    rdfs:comment "Password of the trust store server."@en ;
+.
+
 ids:keyStore a owl:DatatypeProperty;
     rdfs:domain ids:ConfigurationModel;
     rdfs:range xsd:anyURI;
     rdfs:label "key store"@en ;
     rdfs:comment "URI of the key store server."@en ;
+.
+
+ids:keyStorePassword a owl:DatatypeProperty;
+    rdfs:domain ids:ConfigurationModel;
+    rdfs:range xsd:string;
+    rdfs:label "key store password"@en ;
+    rdfs:comment "Password of the key store server."@en ;
 .
 
 ids:configuredBroker a owl:ObjectProperty;


### PR DESCRIPTION
Simple passwords fields are required for truststore / keystore of the Configrauon Model.
See corresponding issue #398

This modeling serves as a temporary solution, as already highlighted in the issue. 