### PR TITLE
Add dct:issued to support LOV interoperability

### DIFF
--- a/Ontology.ttl
+++ b/Ontology.ttl
@@ -37,6 +37,7 @@ ids:
        <https://github.com/mkollenstart> ;
     dct:publisher ids:IDSA ;
     dct:created "2017-09-26"^^xsd:date ;
+    dct:issued "2017-09-26"^^xsd:date ;
     dct:modified "2020-08-10"^^xsd:date ;
     owl:versionInfo "4.0.0" ;
     owl:versionIRI <https://w3id.org/idsa/core/4.0.0> ;


### PR DESCRIPTION
Add `dct:issued` property and set it to the same date as our `dct:created` to foster LOV support.