### PR TITLE
Fix cardinality issues in shacl and minor errors.

### DIFF
--- a/model/communication/Endpoint.ttl
+++ b/model/communication/Endpoint.ttl
@@ -29,7 +29,7 @@ ids:ConnectorEndpoint
     rdfs:label "Connector Endpoint"@en ;
     rdfs:comment "Connector-specific endpoint exposing Artifacts."@en ;
     idsm:validation [
-                        idsm:forProperty ids:accessUrl;
+                        idsm:forProperty ids:accessURL;
                         idsm:constraint idsm:NotNull;
                     ];
         .

--- a/model/contract/Rule.ttl
+++ b/model/contract/Rule.ttl
@@ -114,7 +114,7 @@ ids:assetRefinement
     a owl:ObjectProperty;
     rdfs:subPropertyOf odrl:refinement ;
     rdfs:label "content refinement"@en;
-    rdfs:domain ids:Resource;
+    rdfs:domain ids:Rule;
     rdfs:range ids:AbstractConstraint;
     rdfs:comment "Constraint that refines a (composite) Digital Content."@en.
 

--- a/testing/content/RepresentationShape.ttl
+++ b/testing/content/RepresentationShape.ttl
@@ -50,6 +50,33 @@ shapes:RepresentationShape
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/content/RepresentationShape.ttl> (RepresentationShape): An ids:representationStandard property must not have more than one point from an ids:Representation to a IRI containing the standard."@en ;
 	] ;
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:language ;
+		sh:class ids:Language ;
+		sh:maxCount 1 ;
+		sh:severity sh:Violation ;
+		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/content/RepresentationShape.ttl> (RepresentationShape): An ids:language property must point from an ids:Representation to an ids:Language."@en ;
+	] ;
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:modified ;
+    sh:maxCount 1 ;
+		sh:datatype  xsd:dateTimeStamp ;
+		sh:severity sh:Violation ;
+		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/content/RepresentationShape.ttl> (RepresentationShape): An ids:Representation must have at most one ids:modified attribute pointing to a valid xsd:dateTimeStamp or xsd:date."@en ;
+	] ;
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path ids:created ;
+		sh:datatype  xsd:dateTimeStamp ;
+    sh:maxCount 1 ;
+		sh:severity sh:Violation ;
+		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/content/RepresentationShape.ttl> (RepresentationShape): An ids:Representation must have at most one ids:created attribute pointing to a valid xsd:dateTimeStamp or xsd:date."@en ;
+	] ;
 .
 
 

--- a/testing/contract/ContractShape.ttl
+++ b/testing/contract/ContractShape.ttl
@@ -127,7 +127,22 @@ shapes:ContractShape
 		a sh:PropertyShape ;
 		sh:path ids:prohibition ;
 		sh:class ids:Prohibition ;
-		sh:minCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/contract/ContractShape.ttl> (ContractShape): An ids:Contract must have at least one ids:prohibition to an ids:Prohibition."@en ;
+		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/contract/ContractShape.ttl> (ContractShape): An ids:prohibition must point from an ids:Contract to an ids:Prohibition."@en ;
 	] .
+
+
+	shapes:ContractAgreementShape
+		a sh:NodeShape ;
+		sh:targetClass ids:ContractAgreement ;
+
+		sh:property [
+			a sh:PropertyShape ;
+			sh:path ids:contractStart ;
+			sh:datatype xsd:dateTimeStamp ;
+			sh:minCount 1 ;
+			sh:maxCount 1 ;
+			sh:severity sh:Violation ;
+			sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/contract/ContractShape.ttl> (ContractShape): An ids:contractStart property must point from an ids:ContractAgreement to exactly one xsd:dateTimeStamp."@en ;
+		] ;
+	.

--- a/testing/security/TokenShape.ttl
+++ b/testing/security/TokenShape.ttl
@@ -152,14 +152,14 @@ shapes:JwtPayloadShape
 		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/security/TokenShape.ttl> (JwtPayloadShape): An ids:JwtPayload must have exactly one ids:SecurityProfile linked through the ids:securityProfile property"@en ;
 	] ;
 
-#    sh:property [
-#        a sh:PropertyShape ;
-#        sh:path ids:transportCertsSha256 ;
-#        sh:datatype xsd:string ;
-#        sh:minCount 1;
-#        sh:severity sh:Violation ;
-#        sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/security/TokenShape.ttl> (JwtPayloadShape): The ids:transportCertsSha256 property must point from an ids:JwtPayload to at least one xsd:string containing the SHA256 fingerprints."@en ;
-#	] ;
+  sh:property [
+      a sh:PropertyShape ;
+      sh:path ids:transportCertsSha256 ;
+      sh:datatype xsd:string ;
+      sh:minCount 1;
+      sh:severity sh:Violation ;
+      sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/security/TokenShape.ttl> (JwtPayloadShape): The ids:transportCertsSha256 property must point from an ids:JwtPayload to at least one xsd:string containing the SHA256 fingerprints."@en ;
+] ;
 .
 
 


### PR DESCRIPTION
A few more adjustments to make sure the cardinalities from the idsm:metamodel are translated into shacl correctly, such that generating the java classes based on shacl instead of idsm would also work.