### PR TITLE
Commenting the statement idsm:example  rdfs:range rdf:PlainLiteral . …

### DIFF
--- a/metamodel/Annotation.ttl
+++ b/metamodel/Annotation.ttl
@@ -41,7 +41,7 @@ idsm:example
     # not extending vann:example because derived from rdfs:seeAlso with range rdfs:Resource
     rdfs:label "example"@en;
     rdfs:domain rdfs:Resource;
-    #rdfs:range rdf:PlainLiteral;
+    rdfs:range rdfs:Resource ;
     rdfs:comment "Literal in-line example of instantiating given modeling construct."@en .
 
 idsm:usage

--- a/metamodel/Annotation.ttl
+++ b/metamodel/Annotation.ttl
@@ -41,7 +41,7 @@ idsm:example
     # not extending vann:example because derived from rdfs:seeAlso with range rdfs:Resource
     rdfs:label "example"@en;
     rdfs:domain rdfs:Resource;
-    rdfs:range rdf:PlainLiteral;
+    #rdfs:range rdf:PlainLiteral;
     rdfs:comment "Literal in-line example of instantiating given modeling construct."@en .
 
 idsm:usage


### PR DESCRIPTION
…Pellet gives an inconsistent ontology as the property idsm:example is used with Literal values.