### PR TITLE
Removing minCount 1 for actionRefinement

### DIFF
--- a/testing/contract/ActionShape.ttl
+++ b/testing/contract/ActionShape.ttl
@@ -18,7 +18,7 @@ shapes:ActionShape
 		a sh:PropertyShape ;
 		sh:path ids:actionRefinement ;
 		sh:class ids:Constraint ;
-		sh:minCount 1 ;
+		#sh:minCount 1 ; #The Action codes do not meet this criteria
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/contract/ActionShape.ttl> (ActionShape): An ids:actionRefinement property must have at least one point from an ids:Action to an ids:Constraint."@en ;
 	] ;


### PR DESCRIPTION
As the Codes of Action do not have an actionRefinement defined, we cannot have an sh:minCount 1 in the shapes. Otherwise, the Information model is violating against its own shapes.
This is not meant as a "final solution", but as a hotfix. Adding actionRefinements to the codes also sounds like a legitimate approach.