### PR TITLE
Fixing InfrastructureComponent Shape

### DIFF
--- a/testing/infrastructure/InfrastructureComponentShape.ttl
+++ b/testing/infrastructure/InfrastructureComponentShape.ttl
@@ -27,19 +27,19 @@ shapes:InfrastructureComponentShape
   sh:property [
   	a sh:PropertyShape ;
   	sh:path ids:maintainer ;
-  	sh:class ids:Participant ;
+  	sh:datatype xsd:anyURI ;
     sh:minCount 1 ;
   	sh:severity sh:Violation ;
-  	sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/infrastructure/BrokerShape.ttl> (InfrastructureComponentShape): An ids:maintainer property must have at least one point from an ids:InfrastructureComponent to an ids:Participant."@en ;
+  	sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/infrastructure/InfrastructureComponentShape.ttl> (InfrastructureComponentShape): An ids:maintainer property must have at least one point from an ids:InfrastructureComponent to an ids:Participant."@en ;
   ] ;
 
   sh:property [
     a sh:PropertyShape ;
     sh:path ids:curator ;
-    sh:class ids:Participant ;
+    sh:datatype xsd:anyURI ;
     sh:minCount 1 ;
     sh:severity sh:Violation ;
-    sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/infrastructure/BrokerShape.ttl> (InfrastructureComponentShape): An ids:curator property must have at least one point from an ids:InfrastructureComponent to an ids:Participant."@en ;
+    sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/infrastructure/InfrastructureComponentShape.ttl> (InfrastructureComponentShape): An ids:curator property must have at least one point from an ids:InfrastructureComponent to an ids:Participant."@en ;
   ] ;
 
   sh:property [
@@ -47,7 +47,7 @@ shapes:InfrastructureComponentShape
    sh:path ids:physicalLocation ;
    sh:class ids:Location ;
    sh:severity sh:Violation ;
-   sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/infrastructure/BrokerShape.ttl> (InfrastructureComponentShape): An ids:physicalLocation property must point from an ids:InfrastructureComponent to an ids:Location."@en ;
+   sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/infrastructure/InfrastructureComponentShape.ttl> (InfrastructureComponentShape): An ids:physicalLocation property must point from an ids:InfrastructureComponent to an ids:Location."@en ;
   ] ;
 
   sh:property [
@@ -56,7 +56,7 @@ shapes:InfrastructureComponentShape
     sh:datatype xsd:string ;
     sh:minCount 1 ;
     sh:severity sh:Violation ;
-    sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/infrastructure/BrokerShape.ttl> (InfrastructureComponentShape): An ids:inboundModelVersion property must have at least one point from an ids:InfrastructureComponent to an xsd:string."@en ;
+    sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/infrastructure/InfrastructureComponentShape.ttl> (InfrastructureComponentShape): An ids:inboundModelVersion property must have at least one point from an ids:InfrastructureComponent to an xsd:string."@en ;
   ] ;
 
   sh:property [
@@ -65,7 +65,7 @@ shapes:InfrastructureComponentShape
     sh:datatype xsd:string ;
     sh:minCount 1 ;
     sh:severity sh:Violation ;
-    sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/infrastructure/BrokerShape.ttl> (InfrastructureComponentShape): An ids:outboundModelVersion property must have at least one point from an ids:InfrastructureComponent to an xsd:string."@en ;
+    sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/infrastructure/InfrastructureComponentShape.ttl> (InfrastructureComponentShape): An ids:outboundModelVersion property must have at least one point from an ids:InfrastructureComponent to an xsd:string."@en ;
   ] ;
 
   sh:property [
@@ -73,7 +73,7 @@ shapes:InfrastructureComponentShape
     sh:path ids:componentCertification ;
     sh:class ids:ComponentCertification ;
     sh:severity sh:Violation ;
-    sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/infrastructure/BrokerShape.ttl> (InfrastructureComponentShape): An ids:componentCertification property must point from an ids:InfrastructureComponent to an ids:ComponentCertification."@en ;
+    sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/infrastructure/InfrastructureComponentShape.ttl> (InfrastructureComponentShape): An ids:componentCertification property must point from an ids:InfrastructureComponent to an ids:ComponentCertification."@en ;
   ] ;
 
   sh:property [
@@ -81,6 +81,6 @@ shapes:InfrastructureComponentShape
     sh:path ids:publicKey ;
     sh:class ids:PublicKey ;
     sh:severity sh:Violation ;
-    sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/infrastructure/BrokerShape.ttl> (InfrastructureComponentShape): An ids:publicKey property must point from an ids:InfrastructureComponent to an ids:PublicKey."@en ;
+    sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/infrastructure/InfrastructureComponentShape.ttl> (InfrastructureComponentShape): An ids:publicKey property must point from an ids:InfrastructureComponent to an ids:PublicKey."@en ;
   ] ;
   .


### PR DESCRIPTION
Incorrect links fixed (from BrokerShape to InfrastructureComponentShape
Also changing the datatype of maintainer and curator to xsd:anyURI (the equivalent of "idsm:referenceByUri true")