### PR TITLE
remove "industrial data space" occurrences from ontology

### DIFF
--- a/Ontology.ttl
+++ b/Ontology.ttl
@@ -37,13 +37,12 @@ ids:
        <https://github.com/mkollenstart> ;
     dct:publisher ids:IDSA ;
     dct:created "2017-09-26"^^xsd:date ;
-    dct:issued "2017-09-26"^^xsd:date ;
-    dct:modified "2020-08-10"^^xsd:date ;
+    dct:modified "2021-03-26"^^xsd:date ;
     owl:versionInfo "4.0.0" ;
     owl:versionIRI <https://w3id.org/idsa/core/4.0.0> ;
     vann:preferredNamespaceUri "https://w3id.org/idsa/core/" ;
     vann:preferredNamespacePrefix "ids" ;
-    rdfs:seeAlso <https://industrialdataspace.github.io/InformationModel/> ;
+    rdfs:seeAlso <https://international-data-spaces-association.github.io/InformationModel/> ;
     void:vocabulary
        vann: ,
        void: ,
@@ -133,6 +132,7 @@ ids:
     owl:imports <model/contract/Contract.ttl> ;
     owl:imports <model/contract/LeftOperand.ttl> ;
     owl:imports <model/contract/Rule.ttl> ;
+    owl:imports <model/contract/UsagePolicyClass.ttl> ;
     owl:imports <model/governance/Certification.ttl> ;
     owl:imports <model/governance/License.ttl> ;
     owl:imports <model/infrastructure/AppStore.ttl> ;
@@ -188,4 +188,5 @@ ids:
     owl:imports <codes/RequestTemplate.ttl> ;
     owl:imports <codes/SecurityGuarantee.ttl> ;
     owl:imports <codes/TokenFormat.ttl> ;
+    owl:imports <codes/UsagePolicyClass.ttl> ;
 . 

--- a/Shacl.ttl
+++ b/Shacl.ttl
@@ -11,7 +11,7 @@
 @prefix cc:   <http://creativecommons.org/ns#> .
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#>.
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix shapes: <https://github.com/IndustrialDataSpace/InformationModel/testing/> .
+@prefix shapes: <https://github.com/International-Data-Spaces-Association/InformationModel/tree/master/testing> .
 
 # Description of this ontology module
 # ----------------------------
@@ -30,12 +30,12 @@ shapes:
        <https://github.com/HaydarAk> ;
     dct:publisher ids:IDSA ;
     dct:created "2019-10-14"^^xsd:date ;
-    dct:modified "2020-08-10"^^xsd:date ;
+    dct:modified "2021-03-26"^^xsd:date ;
     owl:versionInfo "4.0.0" ;
-    owl:versionIRI <https://github.com/IndustrialDataSpace/InformationModel/testing/4.0.0> ;
-    vann:preferredNamespaceUri "https://github.com/IndustrialDataSpace/InformationModel/testing/" ;
+    owl:versionIRI <https://github.com/International-Data-Spaces-Association/InformationModel/tree/master/testing/4.0.0> ;
+    vann:preferredNamespaceUri "https://github.com/International-Data-Spaces-Association/InformationModel/tree/master/testing" ;
     vann:preferredNamespacePrefix "shapes" ;
-    rdfs:seeAlso <https://industrialdataspace.github.io/InformationModel/> ;
+    rdfs:seeAlso <https://international-data-spaces-association.github.io/InformationModel/> ;
     void:vocabulary
        sh: ,
        xsd: ,
@@ -67,36 +67,40 @@ ids:IDSA
 # Imports of class files
 shapes:
     owl:imports <testing/communication/ApiDocumentTypeShape.ttl> ;
+    owl:imports <testing/communication/AppRouteShape.ttl> ;
     owl:imports <testing/communication/EndpointShape.ttl> ;
     owl:imports <testing/communication/HostShape.ttl> ;
     owl:imports <testing/communication/InterfaceShape.ttl> ;
     owl:imports <testing/communication/MessageExchangePatternShape.ttl> ;
     owl:imports <testing/communication/MessageShape.ttl> ;
     owl:imports <testing/communication/OperationBindingShape.ttl> ;
-    owl:imports <testing/communication/OperationShape.ttl> ;
     owl:imports <testing/communication/ParameterAssignmentShape.ttl> ;
     owl:imports <testing/communication/ParameterGroupShape.ttl> ;
     owl:imports <testing/communication/ParameterShape.ttl> ;
+    owl:imports <testing/communication/ProxyShape.ttl> ;
     owl:imports <testing/content/ArtifactShape.ttl> ;
     owl:imports <testing/content/AssetShape.ttl> ;
     owl:imports <testing/content/ConceptShape.ttl> ;
     owl:imports <testing/content/DataAppShape.ttl> ;
-    owl:imports <testing/content/DigitalContentShape.ttl> ;
     owl:imports <testing/content/MediaTypeShape.ttl> ;
     owl:imports <testing/content/RepresentationShape.ttl> ;
     owl:imports <testing/content/ResourceShape.ttl> ;
+    owl:imports <testing/content/UsageControlObjectShape.ttl> ;
     owl:imports <testing/context/SpatialEntityShape.ttl> ;
     owl:imports <testing/context/TemporalEntityShape.ttl> ;
     owl:imports <testing/contract/ActionShape.ttl> ;
     owl:imports <testing/contract/ConstraintShape.ttl> ;
     owl:imports <testing/contract/ContractShape.ttl> ;
+    owl:imports <testing/contract/LeftOperandShape.ttl> ;
     owl:imports <testing/contract/PricingModelShape.ttl> ;
     owl:imports <testing/contract/RuleShape.ttl> ;
     owl:imports <testing/governance/CertificationShape.ttl> ;
     owl:imports <testing/infrastructure/BrokerShape.ttl> ;
     owl:imports <testing/infrastructure/CatalogShape.ttl> ;
     owl:imports <testing/infrastructure/ComponentShape.ttl> ;
+    owl:imports <testing/infrastructure/ConfigurationModelShape.ttl> ;
     owl:imports <testing/infrastructure/ConnectorShape.ttl> ;
+    owl:imports <testing/infrastructure/InfrastructureComponentShape.ttl> ;
     owl:imports <testing/infrastructure/ParISSHape.ttl> ;
     owl:imports <testing/infrastructure/PublicKeyShape.ttl> ;
     owl:imports <testing/participant/IndustrialClassificationShape.ttl> ;
@@ -104,6 +108,7 @@ shapes:
     owl:imports <testing/security/AuthInfoShape.ttl> ;
     owl:imports <testing/security/SecurityProfileShape.ttl> ;
     owl:imports <testing/security/TokenShape.ttl> ;
+    owl:imports <testing/security/UserAuthentificationShape.ttl> ;
     owl:imports <testing/shacl/abox-shapes.ttl> ;
     owl:imports <testing/shacl/tbox-shapes.ttl> ;
     owl:imports <testing/shared/DescribedSemanticallyShape.ttl> ;

--- a/create-ontology-ttl.sh
+++ b/create-ontology-ttl.sh
@@ -64,7 +64,7 @@ ids:
     owl:versionIRI <https://w3id.org/idsa/core/${version}> ;
     vann:preferredNamespaceUri "https://w3id.org/idsa/core/" ;
     vann:preferredNamespacePrefix "ids" ;
-    rdfs:seeAlso <https://industrialdataspace.github.io/InformationModel/> ;
+    rdfs:seeAlso <https://international-data-spaces-association.github.io/InformationModel/> ;
     void:vocabulary
        vann: ,
        void: ,

--- a/create-shacl-ttl.sh
+++ b/create-shacl-ttl.sh
@@ -28,7 +28,7 @@ write_to_file()
 @prefix cc:   <http://creativecommons.org/ns#> .
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#>.
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix shapes: <https://github.com/IndustrialDataSpace/InformationModel/testing/> .
+@prefix shapes: <https://github.com/International-Data-Spaces-Association/InformationModel/tree/master/testing> .
 
 EOF
 
@@ -54,10 +54,10 @@ shapes:
     dct:created "2019-10-14"^^xsd:date ;
     dct:modified "$(date +%Y-%m-%d)"^^xsd:date ;
     owl:versionInfo "${version}" ;
-    owl:versionIRI <https://github.com/IndustrialDataSpace/InformationModel/testing/${version}> ;
-    vann:preferredNamespaceUri "https://github.com/IndustrialDataSpace/InformationModel/testing/" ;
+    owl:versionIRI <https://github.com/International-Data-Spaces-Association/InformationModel/tree/master/testing/${version}> ;
+    vann:preferredNamespaceUri "https://github.com/International-Data-Spaces-Association/InformationModel/tree/master/testing" ;
     vann:preferredNamespacePrefix "shapes" ;
-    rdfs:seeAlso <https://industrialdataspace.github.io/InformationModel/> ;
+    rdfs:seeAlso <https://international-data-spaces-association.github.io/InformationModel/> ;
     void:vocabulary
        sh: ,
        xsd: ,

--- a/model/participant/Participant.ttl
+++ b/model/participant/Participant.ttl
@@ -15,13 +15,13 @@ ids:Agent
     a owl:Class;
     rdfs:subClassOf ids:Described, odrl:Party, foaf:Agent ;# odrl:Party makes it a reliable party in contracting
     rdfs:label "Agent"@en;
-    rdfs:comment "Internal or external Agent interacting with the Industrial Data Space, not necessarily an IDS Participant."@en.
+    rdfs:comment "Internal or external Agent interacting with the International Data Spaces, not necessarily an IDS Participant."@en.
 
 ids:Participant
     a owl:Class;
     rdfs:subClassOf ids:Agent, ids:ManagedEntity, org:Organization; # foaf:Organization is implied
     rdfs:label "Participant"@en;
-    rdfs:comment "Stakeholder in the Industrial Data Space, assuming one or more of the predefined roles; every participant is given a unique identity by the Identity Provider."@en;
+    rdfs:comment "Stakeholder in the International Data Spaces, assuming one or more of the predefined roles; every participant is given a unique identity by the Identity Provider."@en;
     idsm:validation [
         idsm:forProperty ids:memberPerson;
         idsm:relationType idsm:OneToMany;

--- a/testing/taxonomies/MessageShape.ttl
+++ b/testing/taxonomies/MessageShape.ttl
@@ -362,7 +362,7 @@ shapes:AppUpdateRequestMessageShape
     sh:pattern "^(?:(http(s)?|idscp|(s)?ftp))";
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (AppUpdateRequestMessageShape): An ids:AppUpdateRequestMessage must point to zero or one IRI reference to an ids:AppResource linked through the ids:affectedDataApp property"@en ;
+		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/taxonomies/MessageShape.ttl> (AppUpdateRequestMessageShape): An ids:AppUpdateRequestMessage must point to zero or one IRI reference to an ids:AppResource linked through the ids:affectedDataApp property"@en ;
 	] .
 
 
@@ -391,9 +391,8 @@ shapes:AppNotificationMessageShape
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (AppNotificationMessageShape): An ids:AppNotificationMessage must have exactly one IRI reference to an ids:Resource linked through the ids:affectedAppResource property"@en ;
+		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/taxonomies/MessageShape.ttl> (AppNotificationMessageShape): An ids:AppNotificationMessage must have exactly one IRI reference to an ids:Resource linked through the ids:affectedAppResource property"@en ;
 	]	.
-
 
 shapes:AppRegistrationRequestMessageShape
 	a sh:NodeShape ;
@@ -406,7 +405,7 @@ shapes:AppRegistrationRequestMessageShape
   	sh:pattern "^(?:(http(s)?|idscp|(s)?ftp))";
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (AppRegistrationRequestMessageShape): An ids:AppRegistrationRequestMessage must have zero or one IRI reference to an ids:AppResource linked through the ids:affectedDataApp property"@en ;
+		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/taxonomies/MessageShape.ttl> (AppRegistrationRequestMessageShape): An ids:AppRegistrationRequestMessage must have zero or one IRI reference to an ids:AppResource linked through the ids:affectedDataApp property"@en ;
 	] ;
 .
 
@@ -422,5 +421,5 @@ shapes:AppUploadMessageShape
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/IndustrialDataSpace/InformationModel/master/testing/taxonomies/MessageShape.ttl> (AppUploadMessageShape): An ids:AppUploadMessage must have exactly one IRI reference to an ids:Artifact linked through the ids:appArtifactResource property"@en ;
+		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/taxonomies/MessageShape.ttl> (AppUploadMessageShape): An ids:AppUploadMessage must have exactly one IRI reference to an ids:Artifact linked through the ids:appArtifactResource property"@en ;
 	] .

--- a/views/GlossaryView.ttl
+++ b/views/GlossaryView.ttl
@@ -46,7 +46,6 @@ idsv:glossaryView a idsm:ModelView;
         ids:IndustrialClassification,
         ids:InfrastructureComponent,
         # Information Model
-        # Industrial Data Space
         ids:LocalDataConfidentiality,
         ids:Message,
         ids:Operation,


### PR DESCRIPTION
Hopefully with the pull request, we remove the last remains of the old name "industrial data spaces"