### PR TITLE
Removing wrong colon

### DIFF
--- a/codes/UsagePolicyClass.ttl
+++ b/codes/UsagePolicyClass.ttl
@@ -7,7 +7,7 @@
 idsc:ALLOW_DATA_USAGE
 	a ids:UsagePolicyClass ;
 	rdfs:label: "Allow data usage" @en;
-	rdfs:comment: "This policy restricts the usage of the data to a specific Data Consumer, regardless of how many connectors they have and without any further usage restriction." @en.
+	rdfs:comment "This policy restricts the usage of the data to a specific Data Consumer, regardless of how many connectors they have and without any further usage restriction." @en.
 	
 idsc:CONNECTOR_RESTRICTED_DATA_USAGE
 	a ids:UsagePolicyClass ;


### PR DESCRIPTION
This colon breaks the parsing of this file, as it results in an illegal URI