### PR TITLE
Fixing ids:unit in shapes

### DIFF
--- a/testing/contract/ConstraintShape.ttl
+++ b/testing/contract/ConstraintShape.ttl
@@ -93,16 +93,16 @@ shapes:ConstraintShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:unit ;
-		sh:class ids:Unit ;
+		sh:nodeKind sh:IRI ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/contract/RuleShape.ttl> (ConstraintShape): An ids:unit property must point from an ids:Constraint to an ids:Unit."@en ;
+		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/contract/RuleShape.ttl> (ConstraintShape): An ids:unit property must point from an ids:Constraint to a unit via a URI."@en ;
 	] ;
 
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:pipEndpoint ;
-		sh:class xsd:anyURI ;
+		sh:nodeKind sh:IRI ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/contract/RuleShape.ttl> (ConstraintShape): An ids:pipEndpoint property must point from an ids:Constraint to an xsd:anyURI."@en ;


### PR DESCRIPTION
ids:Unit was removed, to be replaced with any URI. Hence, we need to adapt the SHACL shape accordingly.