### PR TITLE
Mark ParIS messages as deprecated

### DIFF
--- a/taxonomies/Message.ttl
+++ b/taxonomies/Message.ttl
@@ -388,7 +388,7 @@ ids:ParticipantRequestMessage a owl:Class ;
     rdfs:subClassOf ids:RequestMessage ;
 	owl:deprecated true;
     rdfs:label "Participant Request Message (Deprecated)"@en;
-    rdfs:comment "This class is deprecated. Use ids:DescriptionRequestMessage instead."@en;
+    rdfs:comment "This class is deprecated. Use ids:DescriptionRequestMessage instead. Message asking for retrieving the specified Participants information as the payload of an ids:ParticipantResponse message."@en;
     idsm:validation [
         idsm:forProperty ids:requestedParticipant;
         idsm:constraint idsm:NotNull;
@@ -398,14 +398,15 @@ ids:ParticipantResponseMessage a owl:Class ;
     rdfs:subClassOf ids:ResponseMessage;
 	owl:deprecated true;
     rdfs:label "Participant Response Message (Deprecated)"@en;
-    rdfs:comment "This class is deprecated. Use ids:DescriptionResponseMessage instead."@en.
+    rdfs:comment "This class is deprecated. Use ids:DescriptionResponseMessage instead. ParticipantResponseMessage follows up a ParticipantRequestMessage and contains the Participant's information in the payload section."@en.
 
 ids:requestedParticipant rdf:type owl:ObjectProperty ;
     idsm:referenceByUri true;
+	owl:deprecated true;
     rdfs:domain ids:ParticipantRequestMessage;
     rdfs:range ids:Participant ;
-    rdfs:label "Requested Participant"@en ;
-    rdfs:comment "References a Participant in the context of a request."@en.
+    rdfs:label "Requested Participant (Deprecated)"@en ;
+    rdfs:comment "This property is deprecated. Use ids:requestedElement along with ids:DescriptionRequestMessage instead. References a Participant in the context of a request."@en.
 
 
 # Log messaging

--- a/taxonomies/Message.ttl
+++ b/taxonomies/Message.ttl
@@ -386,8 +386,9 @@ ids:UploadResponseMessage a owl:Class;
 
 ids:ParticipantRequestMessage a owl:Class ;
     rdfs:subClassOf ids:RequestMessage ;
-    rdfs:label "Participant Request Message"@en;
-    rdfs:comment "Message asking for retrieving the specified Participants information as the payload of an ParticipantResponse message."@en;
+	owl:deprecated true;
+    rdfs:label "Participant Request Message (Deprecated)"@en;
+    rdfs:comment "This class is deprecated. Use ids:DescriptionRequestMessage instead."@en;
     idsm:validation [
         idsm:forProperty ids:requestedParticipant;
         idsm:constraint idsm:NotNull;
@@ -395,8 +396,9 @@ ids:ParticipantRequestMessage a owl:Class ;
 
 ids:ParticipantResponseMessage a owl:Class ;
     rdfs:subClassOf ids:ResponseMessage;
-    rdfs:label "Participant Response Message"@en;
-    rdfs:comment "Message that follows up a ParticipantRequestMessage and contains the Participant's information in the payload section."@en.
+	owl:deprecated true;
+    rdfs:label "Participant Response Message (Deprecated)"@en;
+    rdfs:comment "This class is deprecated. Use ids:DescriptionResponseMessage instead."@en.
 
 ids:requestedParticipant rdf:type owl:ObjectProperty ;
     idsm:referenceByUri true;


### PR DESCRIPTION
The `ParticipantRequestMessage`and `ParticipantResponseMessage`  are redundant since the  more general  `DescriptionRequestMessage` and `DescriptionResponseMessage`  can be used for this as well. 

For now, they are marked and commented as deprecated. Will be removed in next major release.