### PR TITLE
Setting the ids:paymentModality to 0 or 1

### DIFF
--- a/testing/content/ResourceShape.ttl
+++ b/testing/content/ResourceShape.ttl
@@ -60,6 +60,7 @@ shapes:ResourceShape
 		a sh:PropertyShape ;
 		sh:path ids:paymentModality ;
 		sh:class ids:PaymentModality ;
+		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/content/ResourceShape.ttl> (ResourceShape): An ids:Resource must have at least one ids:PaymentModality linked through the ids:paymentModality property"@en ;
 	] ;


### PR DESCRIPTION
We have missed the cardinality restriction for the new property. The values are exclusive, so more than one entry makes no sense.