### PR TITLE
Releaxing Resource and Participant entries at the Connector Self-Desc…

### DIFF
--- a/testing/infrastructure/CatalogShape.ttl
+++ b/testing/infrastructure/CatalogShape.ttl
@@ -45,7 +45,10 @@ shapes:ResourceCatalogShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:offeredResources ;
-		sh:class ids:Resource ;
+		sh:or (
+	    [ sh:class ids:Resource ; ]
+	    [ sh:nodeKind sh:IRI ; ]
+		) ;
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/infrastructure/CatalogShape.ttl> (ResourceCatalog): An ids:offeredResource property must point from an ids:ResourceCatalog to an ids:Resource."@en ;
 	] ;
@@ -53,7 +56,10 @@ shapes:ResourceCatalogShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:requestedResource ;
-		sh:class ids:Resource ;
+		sh:or (
+	    [ sh:class ids:Resource ; ]
+	    [ sh:nodeKind sh:IRI ; ]
+		) ;
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/infrastructure/CatalogShape.ttl> (ResourceCatalog): An ids:requestedResource property must point from an ids:ResourceCatalog to an ids:Resource."@en ;
 	] ;
@@ -66,7 +72,10 @@ shapes:ParticipantCatalogShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:member ;
-		sh:class ids:Participant ;
+		sh:or (
+	    [ sh:class ids:Participant ; ]
+	    [ sh:nodeKind sh:IRI ; ]
+		) ;
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/infrastructure/CatalogShape.ttl> (ParticipantCatalog): An ids:member property must point from an ids:ParticipantCatalog to an ids:Participant."@en ;
 	] ;

--- a/testing/infrastructure/InfrastructureComponentShape.ttl
+++ b/testing/infrastructure/InfrastructureComponentShape.ttl
@@ -27,7 +27,10 @@ shapes:InfrastructureComponentShape
   sh:property [
   	a sh:PropertyShape ;
   	sh:path ids:maintainer ;
-  	sh:nodeKind sh:IRI ;
+		sh:or (
+	    [ sh:class ids:Participant ; ]
+	    [ sh:nodeKind sh:IRI ; ]
+		) ;
     sh:minCount 1 ;
   	sh:severity sh:Violation ;
   	sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/infrastructure/InfrastructureComponentShape.ttl> (InfrastructureComponentShape): An ids:maintainer property must have at least one point from an ids:InfrastructureComponent to an ids:Participant."@en ;
@@ -36,7 +39,10 @@ shapes:InfrastructureComponentShape
   sh:property [
     a sh:PropertyShape ;
     sh:path ids:curator ;
-    sh:nodeKind sh:IRI ;
+		sh:or (
+	    [ sh:class ids:Participant ; ]
+	    [ sh:nodeKind sh:IRI ; ]
+		) ;
     sh:minCount 1 ;
     sh:severity sh:Violation ;
     sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/infrastructure/InfrastructureComponentShape.ttl> (InfrastructureComponentShape): An ids:curator property must have at least one point from an ids:InfrastructureComponent to an ids:Participant."@en ;


### PR DESCRIPTION
…ription and the ResourceCatalog. Now, both simple URIs without outgoing elements as well as complex RDF nodes with outgoing Properties are allowed (and can be represented in the generated Java code).

I don't think that this is a breaking change.