### PR TITLE
Relaxing the property ids:standardLicense to have both a URI-referenc…

### DIFF
--- a/testing/taxonomies/DigitalContentShape.ttl
+++ b/testing/taxonomies/DigitalContentShape.ttl
@@ -90,7 +90,10 @@ shapes:DigitalContentShape
 	sh:property [
 		a sh:PropertyShape ;
 		sh:path ids:standardLicense ;
-		sh:nodeKind sh:IRI ;
+		sh:or (
+		  [ sh:nodeKind sh:IRI ; sh:order 1 ; ]
+			[ sh:class ids:Resource ; sh:order 2 ; ]
+		) ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/content/DigitalContentShape.ttl> (DigitalContentShape): An ids:standardLicense property must not have more than one point from an ids:Resource to an xsd:anyURI."@en ;


### PR DESCRIPTION
…e and an RDF instance at the object.

@tomkxy let's use this as a reference to discuss the relaxation requirement from the MDP project.