### PR TITLE
Additional t60 fixes

### DIFF
--- a/codes/Action.ttl
+++ b/codes/Action.ttl
@@ -39,7 +39,7 @@ idsc:AGGREGATE_BY_PROVIDER
 .
 
 idsc:ADD
-    a ids:Action ;
+    a odrl:Action ;
     rdfs:comment "This action modifies a number by adding a given value to it."@en ;
     rdfs:label "add"@en ;
     skos:note "This action modifies a number by adding a given value to it. The field to be modified and the given value are specified in the policy as idsc:JSONPATH/idsc:XPATH and idsc:OPERAND, respectively."@en ;
@@ -55,7 +55,7 @@ idsc:COMPENSATE
     .
 
 idsc:DIVIDE
-    a ids:Action ;
+    a odrl:Action ;
     rdfs:comment "This action modifies dividing something by something else."@en ;
     rdfs:label "divide"@en ;
     skos:note "This action modifies dividing something by something else. The field to be modified and the given value are specified in the policy as idsc:JSONPATH/idsc:XPATH and idsc:OPERAND, respectively."@en ;
@@ -89,14 +89,14 @@ idsc:GRANT_USE
     .
 
 idsc:HASH
-    a ids:Action ;
+    a odrl:Action ;
     rdfs:comment "This action modifies a value by replacing it with a hash of the value."@en ;
     rdfs:label "hash"@en ;
     skos:note "This action modifies a value by replacing it with a hash of the value. The field to be modified and the hash algorithm are specified in the policy as idsc:JSONPATH/idsc:XPATH and idsc:HASH_ALGORITHM (eg. SHA256), respectively."@en ;
     .
 
 idsc:INCREMENT_COUNTER
-    a ids:Action;
+    a odrl:Action ;
     rdfs:label "increment counter"@en;
     rdfs:comment "An action to be used in the count usage policy where the idsc:COUNT left operand is used."@en ;
     .
@@ -127,7 +127,7 @@ idsc:MODIFY
     .
 
 idsc:MULTIPLY
-    a ids:Action ;
+    a odrl:Action ;
     rdfs:comment "This action modifies a number by multiplying it to a given value."@en ;
     rdfs:label "multiply"@en ;
     skos:note "This action modifies a number by multiplying it to a given value. The field to be modified and the given value are specified in the policy as idsc:JSONPATH/idsc:XPATH and idsc:OPERAND, respectively."@en ;
@@ -161,14 +161,14 @@ idsc:READ
     .
 
 idsc:REPLACE
-    a ids:Action ;
+    a odrl:Action ;
     rdfs:comment "To replace some value."@en ;
     rdfs:label "replace"@en ;
     skos:note "This action modifies a value by replacing it with a given value. The field to be modified and the given value are specified in the policy as idsc:JSONPATH/idsc:XPATH and idsc:REPLACE_WITH, respectively."@en ;
 .
 
 idsc:SHUFFLE
-    a ids:Action ;
+    a odrl:Action ;
     rdfs:comment "This action modifies a value by replacing it with an anagram of the value."@en ;
     rdfs:label "shuffle"@en ;
     skos:note "This action modifies a value by replacing it with an anagram of the value. The field to be modified is specified in the policy as idsc:JSONPATH/idsc:XPATH."@en ;

--- a/codes/LeftOperand.ttl
+++ b/codes/LeftOperand.ttl
@@ -47,7 +47,7 @@ idsc:DELAY a odrl:LeftOperand ;
     rdfs:comment "Delay the action. Use idsc:DURATION_EQ, idsc:LONGER, idsc:LONGER_EQ, idsc:SHORTER_EQ, or idsc:SHORTER with datatype xsd:duration."@en ;
 .
 
-idsc:DATE_TIME a ids:LeftOperand ;
+idsc:DATE_TIME a odrl:LeftOperand ;
     rdfs:label "date time"@en ;
     rdfs:comment "The date and time of exercising the action of the Rule. Right operand value must be an xsd:dateTimeStamp."@en ;
 .
@@ -59,7 +59,7 @@ idsc:EVENT a odrl:LeftOperand;
     rdfs:comment "The feature dimension regarding whether current events are happening. Does NOT refer 'events' as in real-time data, sensor observations, or Complex Event Processing but rather as 'World Cup 2018' or 'Hannover Trade Fair'."@en ;
 .
 
-idsc:HASH_ALGORITHM a ids:LeftOperand;
+idsc:HASH_ALGORITHM a odrl:LeftOperand;
     rdfs:label "hash algorithm"@en;
     rdfs:comment "Indicate the hash value to be used, eg.SHA256."@en;
 .
@@ -71,18 +71,18 @@ idsc:STATE a odrl:LeftOperand;
 .
 
 #
-idsc:JSON_PATH a ids:LeftOperand;
+idsc:JSON_PATH a odrl:LeftOperand;
     rdfs:label "json path"@en ;
     rdfs:comment "An expression that refers to a part of a JSON structured data."@en ;
 .
 
-idsc:XPATH a ids:LeftOperand;
+idsc:XPATH a odrl:LeftOperand;
     rdfs:label "xpath"@en ;
     rdfs:comment "An expression that refers to specific elements of an XML document."@en ;
 .
 
 #
-idsc:REPLACE_WITH a ids:LeftOperand;
+idsc:REPLACE_WITH a odrl:LeftOperand;
     rdfs:label "repace with"@en ;
     rdfs:comment "Specifies a new value for a specific field. The action must be idsc:REPLACE and the operator must be idsc:EQUALS."@en ;
 .
@@ -95,7 +95,7 @@ idsc:ABSOLUTE_SPATIAL_POSITION a odrl:LeftOperand ;
     rdfs:comment "The current geospatial position of the *consuming connector*. In case the connector only appears as a virtual entity, the physical location of the hosting server is referenced. Allowed operators are idsc:in. No other spatial operators (close to, north of, etc.) are currently allowed."@en ;
 .
 
-idsc:OPERAND a ids:LeftOperand ;
+idsc:OPERAND a odrl:LeftOperand ;
       rdfs:label "operand"@en ;
       rdfs:comment "To indicate the second operand value for the Actions idsc:ADD, idsc:MULTIPLY and idsc:DIVIDE."@en ;
 .
@@ -107,12 +107,12 @@ idsc:USER a odrl:LeftOperand ;
     rdfs:comment "The user of a system at the *consuming connector* requesting access to a resource. Recommended usage for checking whether the user's role is sufficient for his/her desired action. Allowed operators are idsc:MEMBER_OF, idsc:HAS_MEMBERSHIP, idsc:HAS_SITE with a RightOperand referencing a (set of) acceptable organisations (ids:Participant),memberships, sites. Preferred behaviour is that the RightOperand dereferences to an endpoint hosting the required role information."@en ;
 .
 
-idsc:ROLE a ids:LeftOperand ;
+idsc:ROLE a odrl:LeftOperand ;
     rdfs:label "role"@en ;
     rdfs:comment "As end user role, not the IDS participant type."@en ;
 .
 
-idsc:RECIPIENT a ids:LeftOperand ;
+idsc:RECIPIENT a odrl:LeftOperand ;
     rdfs:label "recipient"@en ;
     rdfs:comment "For example, the recipient of the notify/inform action."@en ;
 .
@@ -125,13 +125,13 @@ idsc:PURPOSE a odrl:LeftOperand;
 .
 
 #
-idsc:TARGET_POLICY a ids:LeftOperand;
+idsc:TARGET_POLICY a odrl:LeftOperand;
     rdfs:label "target policy"@en ;
     rdfs:comment "In order to attach/address a policy to a contract. "@en ;
 .
 
 #
-idsc:ARTIFACT_STATE a ids:LeftOperand;
+idsc:ARTIFACT_STATE a odrl:LeftOperand;
     rdfs:label "artifact state"@en ;
     rdfs:comment "Suggested values exist in the Information Model : idsc:ANONYMIZED, idsc:PSEUDONYMIZED, idsc:ENCRYPTED, idsc:COMBINED. "@en ;
 .
@@ -167,7 +167,7 @@ idsc:SYSTEM a odrl:LeftOperand;
     rdfs:comment "Execution system or execution environment that is used to access the asset under consideration, usually an IDS Connector. The regarded data object should correspond to the IDS Connector class and its attributes. Must be used together with idsc:SAME_AS, idsc:NOT, idsc:HAS_STATE, idsc:IN, idsc:COVERED_BY idsc:INSIDE, idsc:SPATIAL_EQUALS, idsc:DISJOINT, or idsc:INSIDE_NETWORK operators. RightOperandReference must be a URI identifying the target system(s)."@en ;
     .
 
-idsc:SYSTEM_DEVICE a ids:LeftOperand;
+idsc:SYSTEM_DEVICE a odrl:LeftOperand;
     rdfs:label "system device" ;
     rdfs:comment "The ODRL definitions is “An identified computing system or computing device used for exercising the action of the Rule.” "@en ;
     .
@@ -179,22 +179,22 @@ idsc:ENDPOINT a odrl:LeftOperand;
     rdfs:comment "Remote target for an action or information provider (PIP). Must be used together with idsc:IS or idsc:IN operators. RightOperand must be a xsd:anyURI or an URL which should point to an actually deployed endpoint. An example is a refinement of idsc:NOTIFY where idsc:REMOTE points to a Clearing House."@en ;
     .
 
-idsc:APPLICATION a ids:LeftOperand;
+idsc:APPLICATION a odrl:LeftOperand;
     rdfs:label "application" ;
     rdfs:comment "An application is a program or piece of software designed to fulfill a particular purpose. For example, a certified IDS App."@en ;
     .
 
-idsc:CONNECTOR a ids:LeftOperand;
+idsc:CONNECTOR a odrl:LeftOperand;
     rdfs:label "connector" ;
     rdfs:comment "Accepts an IDS connector URI."@en ;
     .
 
-idsc:LOG_LEVEL a ids:LeftOperand;
+idsc:LOG_LEVEL a odrl:LeftOperand;
     rdfs:label "log level" ;
     rdfs:comment "Accepted values: ON_DENY, ON_ALLOW, ON_DUTY_EXERCISED, ON_ACTION_OPERATED."@en ;
     .
 
-idsc:NOTIFICATION_LEVEL a ids:LeftOperand;
+idsc:NOTIFICATION_LEVEL a odrl:LeftOperand;
     rdfs:label "notification level" ;
     rdfs:comment "Similar to the idsc:LOG_LEVEL."@en ;
     .

--- a/codes/RequestTemplate.ttl
+++ b/codes/RequestTemplate.ttl
@@ -32,7 +32,7 @@ idsc:RequestTemplate a ids:PolicyTemplate ;
 			["odrl:constraint" : {    
 					 "odrl:leftOperand" : "<Attribute URI>",
 					 "odrl:operator" : "[ids:eq|ids:lt|ids:gt]",
-					 "ids:rightOperand" : "[<Value URI>|<Value Literal>]"
+					 "odrl:rightOperand" : "[<Value URI>|<Value Literal>]"
 			 } [,]]*
 		} }"""^^xsd:string ;
 	skos:note """@prefix ids: <https://w3id.org/idsa/core/> .
@@ -52,7 +52,7 @@ idsc:RequestTemplate a ids:PolicyTemplate ;
 				odrl:constraint [
 					odrl:leftOperand <Attribute URI> ;
 					odrl:operator [ids:eq|ids:lt|ids:gt] ;
-					ids:rightOperand [<Value URI>|<Value Literal>]
+					odrl:rightOperand [<Value URI>|<Value Literal>]
 				]
 			] ;]*
 		."""^^xsd:string 

--- a/codes/RequestTemplate.ttl
+++ b/codes/RequestTemplate.ttl
@@ -28,7 +28,7 @@ idsc:RequestTemplate a ids:PolicyTemplate ;
 		"ids:provider": "<Provider Participant URI>",
 		"ids:consumer": "<Consumer Participant URI>", 
 		"odrl:permission": {
-			"ids:action": "[ids:use|ids:read|...]" ,
+			"odrl:action": "[ids:use|ids:read|...]" ,
 			["odrl:constraint" : {    
 					 "odrl:leftOperand" : "<Attribute URI>",
 					 "odrl:operator" : "[ids:eq|ids:lt|ids:gt]",
@@ -48,7 +48,7 @@ idsc:RequestTemplate a ids:PolicyTemplate ;
 			ids:consumer <Consumer Participant URI> ;
 			ids:provider <Provider Participant URI>
 			[odrl:permission[
-				ids:action ids:[use|read|...] ;
+				odrl:action ids:[use|read|...] ;
 				odrl:constraint [
 					odrl:leftOperand <Attribute URI> ;
 					odrl:operator [ids:eq|ids:lt|ids:gt] ;

--- a/examples/DATA1.ttl
+++ b/examples/DATA1.ttl
@@ -85,7 +85,7 @@ data1:offer
 				a odrl:Constraint ;
                 odrl:leftOperand     idsc:PAY_AMOUNT ;
                   odrl:operator      idsc:EQUALS ;
-                  ids:rightOperand  25 ;
+                  odrl:rightOperand  25 ;
                   odrl:unit          <http://dbpedia.org/resource/Euro>
             ]
          

--- a/examples/DATA1.ttl
+++ b/examples/DATA1.ttl
@@ -76,11 +76,11 @@ data1:offer
         odrl:assigner part1: ;
         # individual target(s)
         ids:target data1: ;
-        ids:action idsc:USE ;
+        odrl:action idsc:USE ;
         # Obligation
         ids:preDuty [
             a odrl:Duty ;
-            ids:action idsc:COMPENSATE ;
+            odrl:action idsc:COMPENSATE ;
             odrl:constraint [
 				a odrl:Constraint ;
                 odrl:leftOperand     idsc:PAY_AMOUNT ;

--- a/examples/DATA2.ttl
+++ b/examples/DATA2.ttl
@@ -102,7 +102,7 @@ data2:
 			a odrl:Permission ;
             odrl:assigner part1: ;
             ids:target data2:generic_content ; # i.e. applies to any artifact / instance of given content
-            ids:action idsc:USE ;
+            odrl:action idsc:USE ;
         ]
     ] .
 

--- a/examples/DATA3.ttl
+++ b/examples/DATA3.ttl
@@ -73,7 +73,7 @@ data3:offer
         ids:assigner part1: ;
         # individual target(s)
         ids:target data3: ;
-        ids:action idsc:USE ;
+        odrl:action idsc:USE ;
         ids:constraint [
 				    a ids:Constraint ;
             odrl:leftOperand   idsc:SECURITY_LEVEL ;

--- a/examples/DATA3.ttl
+++ b/examples/DATA3.ttl
@@ -1,6 +1,7 @@
 @prefix ids: <https://w3id.org/idsa/core/> .
 @prefix idsc: <https://w3id.org/idsa/code/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 @prefix conn3: <https://aastat.gov.de/connector/conn3/> .
@@ -75,9 +76,9 @@ data3:offer
         ids:action idsc:USE ;
         ids:constraint [
 				    a ids:Constraint ;
-            ids:leftOperand   idsc:SECURITY_LEVEL ;
-            ids:operator      idsc:GTEQ ;
-            ids:rightOperand  idsc:TRUST_SECURITY_PROFILE
+            odrl:leftOperand   idsc:SECURITY_LEVEL ;
+            odrl:operator      idsc:GTEQ ;
+            odrl:rightOperand  idsc:TRUST_SECURITY_PROFILE
         ]
     ] .
 

--- a/examples/TEXT_RESOURCE.ttl
+++ b/examples/TEXT_RESOURCE.ttl
@@ -114,11 +114,11 @@ data1:offer
 
         # individual target(s)
         ids:target _:foo ;
-        ids:action idsc:USE ;
+        odrl:action idsc:USE ;
         # Obligation
         ids:preDuty [
             a odrl:Duty;
-            ids:action idsc:COMPENSATE ;
+            odrl:action idsc:COMPENSATE ;
             odrl:constraint [
                a odrl:Constraint;
                 odrl:leftOperand     idsc:PAY_AMOUNT ;

--- a/examples/TEXT_RESOURCE.ttl
+++ b/examples/TEXT_RESOURCE.ttl
@@ -123,7 +123,7 @@ data1:offer
                a odrl:Constraint;
                 odrl:leftOperand     idsc:PAY_AMOUNT ;
                   odrl:operator      idsc:EQ ;
-                  ids:rightOperand  25 ;
+                  odrl:rightOperand  25 ;
                   odrl:unit         <http://dbpedia.org/resource/Euro>
             ]
         ]

--- a/examples/contracts-and-usage-policy/templates/ActionTemplates/ACTION_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/ActionTemplates/ACTION_TEMPLATE.jsonld
@@ -34,7 +34,7 @@
                 "@type": "ids:Constraint",
                 "odrl:leftOperand": { "@id": "?IdscLeftOperand" },
                 "odrl:operator": { "@id": "?IdsBinaryOperator" },
-                "ids:rightOperand": { "@id": "?Value" }
+                "odrl:rightOperand": { "@id": "?Value" }
                 (, "ids:pipEndpoint": { "@id": "?AttributeLocation" } )?
                 (, "ids:unit": { "@id": "?Unit" } )?
               }

--- a/examples/contracts-and-usage-policy/templates/ActionTemplates/ACTION_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/ActionTemplates/ACTION_TEMPLATE.jsonld
@@ -7,7 +7,7 @@
   { "@id": "?ActionUri" }                                       // directly insert the Action URI, if known
 | // or
   {
-    "@type": "ids:Action",                                      // a Collection with exactly one condition to describe the Action
+    "@type": "odrl:Action",                                      // a Collection with exactly one condition to describe the Action
     "ids:includedIn": { "@id": "?ActionUri"},                   // The general Action, which is further constrained. For instance a idsc:WRITE is only possible if an attribute "color" is equals to "blue"
     "ids:actionRefinement": [
       {
@@ -22,7 +22,7 @@
   }
 | // or
   {
-    "@type": "ids:Action",
+    "@type": "odrl:Action",
     "ids:includedIn": { "@id": "?ActionUri"},
     "ids:actionRefinement": [
       {

--- a/examples/contracts-and-usage-policy/templates/ActionTemplates/ACTION_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/ActionTemplates/ACTION_TEMPLATE.jsonld
@@ -12,9 +12,9 @@
     "ids:actionRefinement": [
       {
         "@type": "ids:Constraint",                              // Define a collection of data objects which, for instance, all have an explicit attribute "color":"blue"
-        "ids:leftOperand": { "@id": "?IdscLeftOperand" },       // The feature of interest, for instance ?IdscLeftOperand := idsc:PATH
-        "ids:operator": { "@id": "?IdscBinaryOperator" },       // The kind of check, which shall be executed on the feature of interest, for instance ?IdscBinaryOperator := idsc:STRING_EQ
-        "ids:rightOperand": { "@id": "?Value" }                 // The value expression all members of this collection have to share, for instance ?Value := "blue"
+        "odrl:leftOperand": { "@id": "?IdscLeftOperand" },       // The feature of interest, for instance ?IdscLeftOperand := idsc:PATH
+        "odrl:operator": { "@id": "?IdscBinaryOperator" },       // The kind of check, which shall be executed on the feature of interest, for instance ?IdscBinaryOperator := idsc:STRING_EQ
+        "odrl:rightOperand": { "@id": "?Value" }                 // The value expression all members of this collection have to share, for instance ?Value := "blue"
         (, "ids:pipEndpoint": { "@id": "?AttributeLocation"} )? // A URI or path expression to the target attribute, ?AttributeLocation := "//color"
         (, "ids:unit": { "@id": "?Unit" } )?                    // A unit which may further explain the ?Value, for instance <http://dbpedia.org/resource/Color>.
       }
@@ -32,8 +32,8 @@
             (
               {
                 "@type": "ids:Constraint",
-                "ids:leftOperand": { "@id": "?IdscLeftOperand" },
-                "ids:operator": { "@id": "?IdsBinaryOperator" },
+                "odrl:leftOperand": { "@id": "?IdscLeftOperand" },
+                "odrl:operator": { "@id": "?IdsBinaryOperator" },
                 "ids:rightOperand": { "@id": "?Value" }
                 (, "ids:pipEndpoint": { "@id": "?AttributeLocation" } )?
                 (, "ids:unit": { "@id": "?Unit" } )?

--- a/examples/contracts-and-usage-policy/templates/ActionTemplates/ACTION_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/ActionTemplates/ACTION_TEMPLATE.ttl
@@ -24,7 +24,7 @@
             a odrl:Constraint ;                              # Define a collection of data objects which, for instance, all have an explicit attribute "color":"blue"
             odrl:leftOperand ?IdscLeftOperand ;              # The feature of interest, for instance ?IdscLeftOperand := idsc:PATH
             odrl:operator ?IdscBinaryOperator ;              # The kind of check, which shall be executed on the feature of interest, for instance ?IdscBinaryOperator := idsc:STRING_EQ
-            ids:rightOperand ?Value ;                       # The value expression all members of this collection have to share, for instance ?Value := "blue"
+            odrl:rightOperand ?Value ;                       # The value expression all members of this collection have to share, for instance ?Value := "blue"
             ( ids:pipEndpoint ?AttributeLocation ; )?   # A URI or path expression to the target attribute, ?AttributeLocation := "//color"
             ( odrl:unit ?Unit ; )?                           # A unit which may further explain the ?Value, for instance <http://dbpedia.org/resource/Color>.
         ]
@@ -41,7 +41,7 @@
                         a odrl:Constraint ;
                         odrl:leftOperand ?IdscLeftOperand ;
                         odrl:operator ?IdsBinaryOperator ;
-                        ids:rightOperand ?Value ;
+                        odrl:rightOperand ?Value ;
                         ( ids:pipEndpoint ?AttributeLocation ; )?
                         ( odrl:unit ?Unit ; )?
                     ){2,} # at least two constraints

--- a/examples/contracts-and-usage-policy/templates/ConnectorbasedAgreementTemplates/CONNECTORBASED_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/ConnectorbasedAgreementTemplates/CONNECTORBASED_AGREEMENT_TEMPLATE.jsonld
@@ -12,7 +12,7 @@
         "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:provider,
         "ids:assignee": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:consumer,
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",

--- a/examples/contracts-and-usage-policy/templates/ConnectorbasedAgreementTemplates/CONNECTORBASED_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/ConnectorbasedAgreementTemplates/CONNECTORBASED_AGREEMENT_TEMPLATE.jsonld
@@ -16,8 +16,8 @@
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:SYSTEM" },
-            "ids:operator": { "@id": "idsc:SAME_AS" },
+            "odrl:leftOperand": { "@id": "idsc:SYSTEM" },
+            "odrl:operator": { "@id": "idsc:SAME_AS" },
             "ids:rightOperandReference": { "@id": "?ConnectorUri" } // the Connector or target system identifier.
           }
         ]

--- a/examples/contracts-and-usage-policy/templates/ConnectorbasedAgreementTemplates/CONNECTORBASED_AGREEMENT_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/ConnectorbasedAgreementTemplates/CONNECTORBASED_AGREEMENT_TEMPLATE.ttl
@@ -25,7 +25,7 @@ idsc:CONNECTORBASED_AGREEMENT_TEMPLATE a ids:ConnectorbasedAgreement ;
         odrl:assigner idsc:PARTICIPANT_TEMPLATE ;            # same value as ids:provider,
         odrl:assignee idsc:PARTICIPANT_TEMPLATE ;            # same value as ids:consumer,
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
             a odrl:Constraint ;
             odrl:leftOperand idsc:SYSTEM ;

--- a/examples/contracts-and-usage-policy/templates/ConnectorbasedAgreementTemplates/CONNECTORBASED_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/ConnectorbasedAgreementTemplates/CONNECTORBASED_OFFER_TEMPLATE.jsonld
@@ -28,8 +28,8 @@
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:SYSTEM" },
-            "ids:operator": { "@id": "idsc:SAME_AS" },
+            "odrl:leftOperand": { "@id": "idsc:SYSTEM" },
+            "odrl:operator": { "@id": "idsc:SAME_AS" },
             "ids:rightOperandReference": { "@id": "?ConnectorUri" } // the Connector or target system identifier.
           }
         ]

--- a/examples/contracts-and-usage-policy/templates/ConnectorbasedAgreementTemplates/CONNECTORBASED_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/ConnectorbasedAgreementTemplates/CONNECTORBASED_OFFER_TEMPLATE.jsonld
@@ -24,7 +24,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
         )
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",

--- a/examples/contracts-and-usage-policy/templates/ConnectorbasedAgreementTemplates/CONNECTORBASED_OFFER_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/ConnectorbasedAgreementTemplates/CONNECTORBASED_OFFER_TEMPLATE.ttl
@@ -37,7 +37,7 @@ idsc:CONNECTORBASED_RESTRICTED_USAGE_OFFER_TEMPLATE a ids:ConnectorbasedOffer ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
             a odrl:Constraint ;
             odrl:leftOperand idsc:SYSTEM ;

--- a/examples/contracts-and-usage-policy/templates/ConnectorbasedAgreementTemplates/CONNECTORBASED_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/ConnectorbasedAgreementTemplates/CONNECTORBASED_REQUEST_TEMPLATE.jsonld
@@ -28,8 +28,8 @@
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:SYSTEM" },
-            "ids:operator": { "@id": "idsc:SAME_AS" },
+            "odrl:leftOperand": { "@id": "idsc:SYSTEM" },
+            "odrl:operator": { "@id": "idsc:SAME_AS" },
             "ids:rightOperandReference": { "@id": "?ConnectorUri" } // the Connector or target system identifier.
           }
         ]

--- a/examples/contracts-and-usage-policy/templates/ConnectorbasedAgreementTemplates/CONNECTORBASED_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/ConnectorbasedAgreementTemplates/CONNECTORBASED_REQUEST_TEMPLATE.jsonld
@@ -24,7 +24,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
         )
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",

--- a/examples/contracts-and-usage-policy/templates/ConnectorbasedAgreementTemplates/CONNECTORBASED_REQUEST_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/ConnectorbasedAgreementTemplates/CONNECTORBASED_REQUEST_TEMPLATE.ttl
@@ -37,7 +37,7 @@ idsc:CONNECTORBASED_RESTRICTED_USAGE_REQUEST_TEMPLATE a ids:ConnectorbasedReques
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
             a odrl:Constraint ;
             odrl:leftOperand idsc:SYSTEM ;

--- a/examples/contracts-and-usage-policy/templates/ConstraintTemplates/CONSTRAINT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/ConstraintTemplates/CONSTRAINT_TEMPLATE.jsonld
@@ -6,8 +6,8 @@
 (
   {
     "@type": "ids:Constraint",                              // Define a collection of data objects which, for instance, all have an explicit attribute "color":"blue"
-    "ids:leftOperand": { "@id": "?IdscLeftOperand" },       // The feature of interest, for instance ?IdscLeftOperand := idsc:PATH
-    "ids:operator": { "@id": "?IdscBinaryOperator" },       // The kind of check, which shall be executed on the feature of interest, for instance ?IdscBinaryOperator := idsc:STRING_EQ
+    "odrl:leftOperand": { "@id": "?IdscLeftOperand" },       // The feature of interest, for instance ?IdscLeftOperand := idsc:PATH
+    "odrl:operator": { "@id": "?IdscBinaryOperator" },       // The kind of check, which shall be executed on the feature of interest, for instance ?IdscBinaryOperator := idsc:STRING_EQ
     "ids:rightOperand": { "@id": "?Value" }                 // The value expression all members of this collection have to share, for instance ?Value := "blue"
     (, "ids:pipEndpoint": { "@id": "?AttributeLocation"} )? // A URI or path expression to the target attribute, ?AttributeLocation := "//color"
     (, "ids:unit": { "@id": "?Unit" } )?                    // A unit which may further explain the ?Value, for instance <http://dbpedia.org/resource/Color>.
@@ -20,8 +20,8 @@
         (
           {
             "@type": "ids:Constraint",
-            "ids:leftOperand": { "@id": "?IdscLeftOperand" },
-            "ids:operator": { "@id": "?IdsBinaryOperator" },
+            "odrl:leftOperand": { "@id": "?IdscLeftOperand" },
+            "odrl:operator": { "@id": "?IdsBinaryOperator" },
             "ids:rightOperand": { "@id": "?Value" }
             (, "ids:pipEndpoint": { "@id": "?AttributeLocation" } )?
             (, "ids:unit": { "@id": "?Unit" } )?

--- a/examples/contracts-and-usage-policy/templates/ConstraintTemplates/CONSTRAINT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/ConstraintTemplates/CONSTRAINT_TEMPLATE.jsonld
@@ -8,7 +8,7 @@
     "@type": "ids:Constraint",                              // Define a collection of data objects which, for instance, all have an explicit attribute "color":"blue"
     "odrl:leftOperand": { "@id": "?IdscLeftOperand" },       // The feature of interest, for instance ?IdscLeftOperand := idsc:PATH
     "odrl:operator": { "@id": "?IdscBinaryOperator" },       // The kind of check, which shall be executed on the feature of interest, for instance ?IdscBinaryOperator := idsc:STRING_EQ
-    "ids:rightOperand": { "@id": "?Value" }                 // The value expression all members of this collection have to share, for instance ?Value := "blue"
+    "odrl:rightOperand": { "@id": "?Value" }                 // The value expression all members of this collection have to share, for instance ?Value := "blue"
     (, "ids:pipEndpoint": { "@id": "?AttributeLocation"} )? // A URI or path expression to the target attribute, ?AttributeLocation := "//color"
     (, "ids:unit": { "@id": "?Unit" } )?                    // A unit which may further explain the ?Value, for instance <http://dbpedia.org/resource/Color>.
   }
@@ -22,7 +22,7 @@
             "@type": "ids:Constraint",
             "odrl:leftOperand": { "@id": "?IdscLeftOperand" },
             "odrl:operator": { "@id": "?IdsBinaryOperator" },
-            "ids:rightOperand": { "@id": "?Value" }
+            "odrl:rightOperand": { "@id": "?Value" }
             (, "ids:pipEndpoint": { "@id": "?AttributeLocation" } )?
             (, "ids:unit": { "@id": "?Unit" } )?
           }

--- a/examples/contracts-and-usage-policy/templates/ConstraintTemplates/CONSTRAINT_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/ConstraintTemplates/CONSTRAINT_TEMPLATE.ttl
@@ -19,7 +19,7 @@
         a odrl:Constraint ;                                  # Constraint
         odrl:leftOperand ?IdscLeftOperand ;                  # The feature of interest, for instance ?IdscLeftOperand := idsc:PAY_AMOUNT
         ids:operator ?IdscBinaryOperator ;                  # The kind of check, which shall be executed on the feature of interest, for instance ?IdscBinaryOperator := idsc:EQ
-        ids:rightOperand ?Value ;                           # The value expression all members of this collection have to share, for instance ?Value := "5"
+        odrl:rightOperand ?Value ;                           # The value expression all members of this collection have to share, for instance ?Value := "5"
         ( ids:pipEndpoint ?AttributeLocation ; )?       # A URI or path expression to the target attribute, ?AttributeLocation := <https://bank.com/bankaccount>
         ( odrl:unit ?Unit ; )?                               # A unit which may further explain the ?Value, for instance <http://dbpedia.org/resource/Euro>.
     ]
@@ -32,7 +32,7 @@
                     a odrl:Constraint ;
                     odrl:leftOperand ?IdscLeftOperand ;
                     ids:operator ?IdsBinaryOperator ;
-                    ids:rightOperand ?Value ;
+                    odrl:rightOperand ?Value ;
                     ( ids:pipEndpoint ?AttributeLocation ; )?
                     ( odrl:unit ?Unit ; )?
                 ){2,} # at least two constraints

--- a/examples/contracts-and-usage-policy/templates/ConstraintTemplates/TEMPORAL_CONSTRAINT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/ConstraintTemplates/TEMPORAL_CONSTRAINT_TEMPLATE.jsonld
@@ -6,8 +6,8 @@
 (
   {
     "@type": "ids:TemporalConstraint",                                          // A TemporalConstraint, for instance current time > January 1st 2020
-    "ids:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },                // The current time, usually the system time.
-    "ids:operator": { "@id":
+    "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },                // The current time, usually the system time.
+    "odrl:operator": { "@id":
       ("idsc:AFTER" | "idsc:BEFORE" | "idsc:CONTAINS" | "idsc:TEMPORAL_DISJOINT"
       | "idsc:DURING" | "idsc:TEMPORAL_EQUALS" | "idsc:FINISHED_BY"
       | "idsc:FINISHES" | "idsc:MEETS" | "idsc:MET_BY" | "idsc:OVERLAPS"
@@ -22,8 +22,8 @@
 | // or
   {
     "@type": "ids:TemporalConstraint",                                          // A TemporalConstraint, for instance usage time < 10 minutes
-    "ids:leftOperand": { "@id": "idsc:ELAPSED_TIME" },                          // The overall usage time of the asset, must be provided by the usage enforcement engine or the IDS Connector.
-    "ids:operator": { "@id":
+    "odrl:leftOperand": { "@id": "idsc:ELAPSED_TIME" },                          // The overall usage time of the asset, must be provided by the usage enforcement engine or the IDS Connector.
+    "odrl:operator": { "@id":
       ("idsc:SHORTER" | "idsc:SHORTER_EQ" | "idsc:LONGER" | "idsc:LONGER_EQ"
       | "idsc:DURATION_EQ")                                                     // The comaprison operator, for instance idsc:SHORTER
     },
@@ -40,8 +40,8 @@
       "@list": [                                                                // LogicalConstraints allow the expression of complex constraints. For instance, we can restrict the policy to be only valid in 2020.
         {
           "@type": "ids:TemporalConstraint",                                    // A TemporalConstraint, for instance current time > January 1st 2020
-          "ids:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },          // The current time, usually the system time.
-          "ids:operator": { "@id": "idsc:AFTER" },
+          "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },          // The current time, usually the system time.
+          "odrl:operator": { "@id": "idsc:AFTER" },
           "ids:rightOperand": {
             "@id": "?Value",                                                    // The value expression, for instance ?Value := "2020-01-01T00:00:00.000+02:00"
             "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
@@ -50,8 +50,8 @@
         },
         {
           "@type": "ids:TemporalConstraint",                                    // A TemporalConstraint, for instance current time < January 1st 2021
-          "ids:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },          // The current time, usually the system time.
-          "ids:operator": { "@id": "idsc:BEFORE" },
+          "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },          // The current time, usually the system time.
+          "odrl:operator": { "@id": "idsc:BEFORE" },
           "ids:rightOperand": {
             "@id": "?Value",                                                    // The value expression, for instance ?Value := "2020-12-12T23:59:59.999+02:00"
             "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"

--- a/examples/contracts-and-usage-policy/templates/ConstraintTemplates/TEMPORAL_CONSTRAINT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/ConstraintTemplates/TEMPORAL_CONSTRAINT_TEMPLATE.jsonld
@@ -13,7 +13,7 @@
       | "idsc:FINISHES" | "idsc:MEETS" | "idsc:MET_BY" | "idsc:OVERLAPS"
       | "idsc:OVERLAPPED_BY" | "idsc:STARTS" | "idsc:STARTED_BY")               // The comaprison operator, for instance idsc:AFTER
     },
-    "ids:rightOperand": {
+    "odrl:rightOperand": {
       "@id": "?Value",                                                          // The value expression, for instance ?Value := "2020-01-01T00:00:00.000+02:00"
       "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
     }
@@ -27,7 +27,7 @@
       ("idsc:SHORTER" | "idsc:SHORTER_EQ" | "idsc:LONGER" | "idsc:LONGER_EQ"
       | "idsc:DURATION_EQ")                                                     // The comaprison operator, for instance idsc:SHORTER
     },
-    "ids:rightOperand": {
+    "odrl:rightOperand": {
       "@id": "?Value",                                                          // The value expression, for instance ?Value := "P0Y0M0DT0H10M0S"
       "@type": "http://www.w3.org/2001/XMLSchema#duration"
     }
@@ -42,7 +42,7 @@
           "@type": "ids:TemporalConstraint",                                    // A TemporalConstraint, for instance current time > January 1st 2020
           "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },          // The current time, usually the system time.
           "odrl:operator": { "@id": "idsc:AFTER" },
-          "ids:rightOperand": {
+          "odrl:rightOperand": {
             "@id": "?Value",                                                    // The value expression, for instance ?Value := "2020-01-01T00:00:00.000+02:00"
             "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
           }
@@ -52,7 +52,7 @@
           "@type": "ids:TemporalConstraint",                                    // A TemporalConstraint, for instance current time < January 1st 2021
           "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },          // The current time, usually the system time.
           "odrl:operator": { "@id": "idsc:BEFORE" },
-          "ids:rightOperand": {
+          "odrl:rightOperand": {
             "@id": "?Value",                                                    // The value expression, for instance ?Value := "2020-12-12T23:59:59.999+02:00"
             "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
           }

--- a/examples/contracts-and-usage-policy/templates/ConstraintTemplates/TEMPORAL_CONSTRAINT_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/ConstraintTemplates/TEMPORAL_CONSTRAINT_TEMPLATE.ttl
@@ -22,7 +22,7 @@
           idsc:TEMPORAL_DISJOINT | idsc:DURING | idsc:TEMPORAL_EQUALS |
           idsc:FINISHED_BY | idsc:FINISHES | idsc:MEETS | idsc:MET_BY |
           idsc:OVERLAPS | idsc:OVERLAPPED_BY | idsc:STARTS | idsc:STARTED_BY) ; # The comaprison operator, for instance AFTER
-        ids:rightOperand "?Value"^^xsd:dateTimeStamp ;                          # The value expression, for instance ?Value := "2020-01-01T00:00:00.000+02:00"
+        odrl:rightOperand "?Value"^^xsd:dateTimeStamp ;                          # The value expression, for instance ?Value := "2020-01-01T00:00:00.000+02:00"
         ( ids:pipEndpoint ?ClockEndpoint ; )?                               # A URI or path expression to a shared time provider, if necessary.
     )
 | # or
@@ -31,7 +31,7 @@
         odrl:leftOperand idsc:ELAPSED_TIME ;                                     # The overall usage time of the asset, must be provided by the usage enforcement engine or the IDS Connector.
         ids:operator ( idsc:SHORTER | idsc:SHORTER_EQ | idsc:LONGER |
           idsc:LONGER_EQ | idsc:DURATION_EQ ) ;                                 # The comaprison operator, for instance SHORTER
-        ids:rightOperand "?Value"^^xsd:duration ;                               # The value expression, for instance ?Value := "P0Y0M0DT0H10M0S"
+        odrl:rightOperand "?Value"^^xsd:duration ;                               # The value expression, for instance ?Value := "P0Y0M0DT0H10M0S"
         ( ids:pipEndpoint ?ClockEndpoint ; )?                               # A URI or path expression to a provider of the usage duration.
     )
 | # or
@@ -43,14 +43,14 @@
                   a ids:TemporalConstraint ;                                    # A TemporalConstraint, for instance current time > January 1st 2020
                   odrl:leftOperand idsc:POLICY_EVALUATION_TIME ;                 # The current time, usually the system time.
                   ids:operator idsc:AFTER ;                                     # The comaprison operator, for instance AFTER
-                  ids:rightOperand "?Value"^^xsd:dateTimeStamp ;                # The value expression, for instance ?Value := "2020-01-01T00:00:00.000+02:00"
+                  odrl:rightOperand "?Value"^^xsd:dateTimeStamp ;                # The value expression, for instance ?Value := "2020-01-01T00:00:00.000+02:00"
                   ( ids:pipEndpoint ?ClockEndpoint ; )?                     # A URI or path expression to a shared time provider, if necessary.
               ]
               [
                   a ids:TemporalConstraint ;                                    # A TemporalConstraint, for instance current time < January 1st 2021
                   odrl:leftOperand idsc:POLICY_EVALUATION_TIME ;                 # The current time, usually the system time.
                   ids:operator idsc:BEFORE ;                                    # The comaprison operator, for instance AFTER
-                  ids:rightOperand "?Value"^^xsd:dateTimeStamp ;                # The value expression, for instance ?Value := "2020-12-12T23:59:59.999+02:00"
+                  odrl:rightOperand "?Value"^^xsd:dateTimeStamp ;                # The value expression, for instance ?Value := "2020-12-12T23:59:59.999+02:00"
                   ( ids:pipEndpoint ?ClockEndpoint ; )?                     # A URI or path expression to a shared time provider, if necessary.
               ]
             ) # ')' is used as an RDF List operator here

--- a/examples/contracts-and-usage-policy/templates/DistributeEncryptedTemplates/DISTRIBUTE_ENCRYPTED_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/DistributeEncryptedTemplates/DISTRIBUTE_ENCRYPTED_AGREEMENT_TEMPLATE.jsonld
@@ -12,12 +12,12 @@
         "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:provider,
         "ids:assignee": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:consumer,
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": { "@id": "idsc:DISTRIBUTE"},
+        "odrl:action": { "@id": "idsc:DISTRIBUTE"},
         "ids:preDuty": {
             "@type": "ids:Duty",
             "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),          // same value as ids:provider,
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE),          // same value as ids:consumer,
-            "ids:action": { "@id": "idsc:ENCRYPT" }
+            "odrl:action": { "@id": "idsc:ENCRYPT" }
         }
         (, "ids:constraint": (idsc:CONSTRAINT_TEMPLATE) )*        // zero or more Constraints
         (, "ids:preDuty": (idsc:OBLIGATION_TEMPLATE) )*     // zero or more additional Obligations which need to be fulfilled before the Usage event

--- a/examples/contracts-and-usage-policy/templates/DistributeEncryptedTemplates/DISTRIBUTE_ENCRYPTED_AGREEMENT_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/DistributeEncryptedTemplates/DISTRIBUTE_ENCRYPTED_AGREEMENT_TEMPLATE.ttl
@@ -25,12 +25,12 @@ idsc:DISTRIBUTE_ENCRYPTED_AGREEMENT_TEMPLATE a ids:DistributeEcryptedAgreement ;
         odrl:assigner idsc:PARTICIPANT_TEMPLATE ;            # same value as ids:provider
         odrl:assignee idsc:PARTICIPANT_TEMPLATE ;            # same value as ids:consumer
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:DISTRIBUTE ;
+        odrl:action idsc:DISTRIBUTE ;
         ids:preDuty [
             a odrl:Duty ;
             odrl:assigner idsc:PARTICIPANT_TEMPLATE ;        # same value as ids:provider
             odrl:assignee idsc:PARTICIPANT_TEMPLATE ;        # same value as ids:consumer
-            ids:action idsc:ENCRYPT ;
+            odrl:action idsc:ENCRYPT ;
         ] ;
         ( odrl:constraint idsc:CONSTRAINT_TEMPLATE ; )*      # zero or more Constraints
         ( ids:preDuty idsc:OBLIGATION_TEMPLATE ; )*   # zero or more additional Obligations which need to be fulfilled before the Usage event

--- a/examples/contracts-and-usage-policy/templates/DistributeEncryptedTemplates/DISTRIBUTE_ENCRYPTED_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/DistributeEncryptedTemplates/DISTRIBUTE_ENCRYPTED_OFFER_TEMPLATE.jsonld
@@ -24,7 +24,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
         )
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": { "@id": "idsc:DISTRIBUTE"},
+        "odrl:action": { "@id": "idsc:DISTRIBUTE"},
         "ids:preDuty": {
             "@type": "ids:Duty",
             (
@@ -35,7 +35,7 @@
               ( "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),           // same value as ids:provider
                 "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
             )
-            "ids:action": { "@id": "idsc:ENCRYPT" }
+            "odrl:action": { "@id": "idsc:ENCRYPT" }
         }
         (, "ids:constraint": (idsc:CONSTRAINT_TEMPLATE) )*        // zero or more Constraints
         (, "ids:preDuty": (idsc:OBLIGATION_TEMPLATE) )*     // zero or more additional Obligations which need to be fulfilled before the Usage event

--- a/examples/contracts-and-usage-policy/templates/DistributeEncryptedTemplates/DISTRIBUTE_ENCRYPTED_OFFER_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/DistributeEncryptedTemplates/DISTRIBUTE_ENCRYPTED_OFFER_TEMPLATE.ttl
@@ -37,7 +37,7 @@ idsc:DISTRIBUTE_ENCRYPTED_OFFER_TEMPLATE a ids:DistributeEcryptedOffer ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:DISTRIBUTE ;
+        odrl:action idsc:DISTRIBUTE ;
         ids:preDuty [
             a odrl:Duty ;
             (
@@ -48,7 +48,7 @@ idsc:DISTRIBUTE_ENCRYPTED_OFFER_TEMPLATE a ids:DistributeEcryptedOffer ;
               (odrl:assigner idsc:PARTICIPANT_TEMPLATE ;         # same value as ids:provider
                odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
             )
-            ids:action idsc:ENCRYPT ;
+            odrl:action idsc:ENCRYPT ;
         ] ;
         ( odrl:constraint idsc:CONSTRAINT_TEMPLATE ; )*      # zero or more Constraints
         ( ids:preDuty idsc:OBLIGATION_TEMPLATE ; )*   # zero or more additional Obligations which need to be fulfilled before the Usage event

--- a/examples/contracts-and-usage-policy/templates/DistributeEncryptedTemplates/DISTRIBUTE_ENCRYPTED_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/DistributeEncryptedTemplates/DISTRIBUTE_ENCRYPTED_REQUEST_TEMPLATE.jsonld
@@ -24,7 +24,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
         )
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": { "@id": "idsc:DISTRIBUTE"},
+        "odrl:action": { "@id": "idsc:DISTRIBUTE"},
         "ids:preDuty": {
             "@type": "ids:Duty",
             (
@@ -35,7 +35,7 @@
               ( "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),           // same value as ids:provider
                 "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
             )
-            "ids:action": { "@id": "idsc:ENCRYPT" }
+            "odrl:action": { "@id": "idsc:ENCRYPT" }
         }
         (, "ids:constraint": (idsc:CONSTRAINT_TEMPLATE) )*        // zero or more Constraints
         (, "ids:preDuty": (idsc:OBLIGATION_TEMPLATE) )*     // zero or more additional Obligations which need to be fulfilled before the Usage event

--- a/examples/contracts-and-usage-policy/templates/DistributeEncryptedTemplates/DISTRIBUTE_ENCRYPTED_REQUEST_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/DistributeEncryptedTemplates/DISTRIBUTE_ENCRYPTED_REQUEST_TEMPLATE.ttl
@@ -37,7 +37,7 @@ idsc:DISTRIBUTE_ENCRYPTED_REQUEST_TEMPLATE a ids:DistributeEcryptedRequest ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:DISTRIBUTE ;
+        odrl:action idsc:DISTRIBUTE ;
         ids:preDuty [
             a odrl:Duty ;
             (
@@ -48,7 +48,7 @@ idsc:DISTRIBUTE_ENCRYPTED_REQUEST_TEMPLATE a ids:DistributeEcryptedRequest ;
               (odrl:assigner idsc:PARTICIPANT_TEMPLATE ;         # same value as ids:provider
                odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
             )
-            ids:action idsc:ENCRYPT ;
+            odrl:action idsc:ENCRYPT ;
         ] ;
         ( odrl:constraint idsc:CONSTRAINT_TEMPLATE ; )*      # zero or more Constraints
         ( ids:preDuty idsc:OBLIGATION_TEMPLATE ; )*   # zero or more additional Obligations which need to be fulfilled before the Usage event

--- a/examples/contracts-and-usage-policy/templates/EventRestrictedUsage/EVENT_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/EventRestrictedUsage/EVENT_AGREEMENT_TEMPLATE.jsonld
@@ -12,7 +12,7 @@
         "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:provider,
         "ids:assignee": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:consumer,
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": [{
             "@type": "ids:Constraint",
             "odrl:leftOperand": {

--- a/examples/contracts-and-usage-policy/templates/EventRestrictedUsage/EVENT_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/EventRestrictedUsage/EVENT_AGREEMENT_TEMPLATE.jsonld
@@ -15,10 +15,10 @@
         "ids:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": [{
             "@type": "ids:Constraint",
-            "ids:leftOperand": {
+            "odrl:leftOperand": {
               "@id": "idsc:EVENT"
             },
-            "ids:operator": { "@id": "idsc:EQUALS" },             // if pipReturnValue == true --> Constraint is staisfied
+            "odrl:operator": { "@id": "idsc:EQUALS" },             // if pipReturnValue == true --> Constraint is staisfied
             "ids:rightOperand": {
                 "@value": "?eventUri",
                 "@type": "xsd:anyURI"

--- a/examples/contracts-and-usage-policy/templates/EventRestrictedUsage/EVENT_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/EventRestrictedUsage/EVENT_AGREEMENT_TEMPLATE.jsonld
@@ -19,7 +19,7 @@
               "@id": "idsc:EVENT"
             },
             "odrl:operator": { "@id": "idsc:EQUALS" },             // if pipReturnValue == true --> Constraint is staisfied
-            "ids:rightOperand": {
+            "odrl:rightOperand": {
                 "@value": "?eventUri",
                 "@type": "xsd:anyURI"
             },

--- a/examples/contracts-and-usage-policy/templates/EventRestrictedUsage/EVENT_AGREEMENT_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/EventRestrictedUsage/EVENT_AGREEMENT_TEMPLATE.ttl
@@ -32,7 +32,7 @@ idsc:EVENT_AGREEMENT_TEMPLATE a ids:EventAgreement ;
               ids:broader idsc:EVENT ;
             ] ;
             odrl:operator idsc:EQUALS ;                    # if pipReturnValue == true --> Constraint is staisfied
-            ids:rightOperand "true"^^xsd:boolean ;        # for a certain usage ?duration
+            odrl:rightOperand "true"^^xsd:boolean ;        # for a certain usage ?duration
             ids:pipEndpoint ?askIfEventPipUri ;           # The PIP call for this event, for instance https//pip.com/path/isFIFA_World_Cup_tournaments or https//pip.com/ids?event=FIFA_World_Cup_tournaments
         ] ;
     ]

--- a/examples/contracts-and-usage-policy/templates/EventRestrictedUsage/EVENT_AGREEMENT_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/EventRestrictedUsage/EVENT_AGREEMENT_TEMPLATE.ttl
@@ -24,7 +24,7 @@ idsc:EVENT_AGREEMENT_TEMPLATE a ids:EventAgreement ;
         odrl:assigner idsc:PARTICIPANT_TEMPLATE ;            # same value as ids:provider
         odrl:assignee idsc:PARTICIPANT_TEMPLATE ;            # same value as ids:consumer
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
             a odrl:Constraint ;
             odrl:leftOperand [

--- a/examples/contracts-and-usage-policy/templates/EventRestrictedUsage/EVENT_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/EventRestrictedUsage/EVENT_OFFER_TEMPLATE.jsonld
@@ -32,7 +32,7 @@
               "ids:broader" : "idsc:EVENT"
             },
             "odrl:operator": { "@id": "idsc:EQUALS" },             // if pipReturnValue == true --> Constraint is staisfied
-            "ids:rightOperand": {
+            "odrl:rightOperand": {
                 "@value": "true",
                 "@type": "http://www.w3.org/2001/XMLSchema#:boolean"
             },

--- a/examples/contracts-and-usage-policy/templates/EventRestrictedUsage/EVENT_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/EventRestrictedUsage/EVENT_OFFER_TEMPLATE.jsonld
@@ -27,11 +27,11 @@
         "ids:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": {
             "@type": "ids:Constraint",
-            "ids:leftOperand": {
+            "odrl:leftOperand": {
               "@id": "?EventURI",                                 // The identifier of this event, for instance http://dbpedia.org/resource/Category:FIFA_World_Cup_tournaments
               "ids:broader" : "idsc:EVENT"
             },
-            "ids:operator": { "@id": "idsc:EQUALS" },             // if pipReturnValue == true --> Constraint is staisfied
+            "odrl:operator": { "@id": "idsc:EQUALS" },             // if pipReturnValue == true --> Constraint is staisfied
             "ids:rightOperand": {
                 "@value": "true",
                 "@type": "http://www.w3.org/2001/XMLSchema#:boolean"

--- a/examples/contracts-and-usage-policy/templates/EventRestrictedUsage/EVENT_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/EventRestrictedUsage/EVENT_OFFER_TEMPLATE.jsonld
@@ -24,7 +24,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
         )
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": {
             "@type": "ids:Constraint",
             "odrl:leftOperand": {

--- a/examples/contracts-and-usage-policy/templates/EventRestrictedUsage/EVENT_OFFER_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/EventRestrictedUsage/EVENT_OFFER_TEMPLATE.ttl
@@ -44,7 +44,7 @@ idsc:EVENT_OFFER_TEMPLATE a ids:EventOffer ;
               ids:broader idsc:EVENT ;
             ] ;
             odrl:operator idsc:EQUALS ;                    # if pipReturnValue == true --> Constraint is staisfied
-            ids:rightOperand "true"^^xsd:boolean ;        # for a certain usage ?duration
+            odrl:rightOperand "true"^^xsd:boolean ;        # for a certain usage ?duration
             ids:pipEndpoint ?askIfEventPipUri ;           # The PIP call for this event, for instance https//pip.com/path/isFIFA_World_Cup_tournaments or https//pip.com/ids?event=FIFA_World_Cup_tournaments
         ] ;
     ]

--- a/examples/contracts-and-usage-policy/templates/EventRestrictedUsage/EVENT_OFFER_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/EventRestrictedUsage/EVENT_OFFER_TEMPLATE.ttl
@@ -36,7 +36,7 @@ idsc:EVENT_OFFER_TEMPLATE a ids:EventOffer ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
             a odrl:Constraint ;
             odrl:leftOperand [

--- a/examples/contracts-and-usage-policy/templates/EventRestrictedUsage/EVENT_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/EventRestrictedUsage/EVENT_REQUEST_TEMPLATE.jsonld
@@ -32,7 +32,7 @@
               "ids:broader" : "idsc:EVENT"
             },
             "odrl:operator": { "@id": "idsc:EQUALS" },             // if pipReturnValue == true --> Constraint is staisfied
-            "ids:rightOperand": {
+            "odrl:rightOperand": {
                 "@value": "true",
                 "@type": "http://www.w3.org/2001/XMLSchema#boolean"
             },

--- a/examples/contracts-and-usage-policy/templates/EventRestrictedUsage/EVENT_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/EventRestrictedUsage/EVENT_REQUEST_TEMPLATE.jsonld
@@ -24,7 +24,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
         )
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": {
             "@type": "ids:Constraint",
             "odrl:leftOperand": {

--- a/examples/contracts-and-usage-policy/templates/EventRestrictedUsage/EVENT_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/EventRestrictedUsage/EVENT_REQUEST_TEMPLATE.jsonld
@@ -27,11 +27,11 @@
         "ids:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": {
             "@type": "ids:Constraint",
-            "ids:leftOperand": {
+            "odrl:leftOperand": {
               "@id": "?EventURI",                                 // The identifier of this event, for instance http://dbpedia.org/resource/Category:FIFA_World_Cup_tournaments
               "ids:broader" : "idsc:EVENT"
             },
-            "ids:operator": { "@id": "idsc:EQUALS" },             // if pipReturnValue == true --> Constraint is staisfied
+            "odrl:operator": { "@id": "idsc:EQUALS" },             // if pipReturnValue == true --> Constraint is staisfied
             "ids:rightOperand": {
                 "@value": "true",
                 "@type": "http://www.w3.org/2001/XMLSchema#boolean"

--- a/examples/contracts-and-usage-policy/templates/EventRestrictedUsage/EVENT_REQUEST_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/EventRestrictedUsage/EVENT_REQUEST_TEMPLATE.ttl
@@ -36,7 +36,7 @@ idsc:EVENT_REQUEST_TEMPLATE a ids:EventRequest ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
             a odrl:Constraint ;
             odrl:leftOperand [

--- a/examples/contracts-and-usage-policy/templates/EventRestrictedUsage/EVENT_REQUEST_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/EventRestrictedUsage/EVENT_REQUEST_TEMPLATE.ttl
@@ -44,7 +44,7 @@ idsc:EVENT_REQUEST_TEMPLATE a ids:EventRequest ;
               ids:broader idsc:EVENT ;
             ] ;
             odrl:operator idsc:EQUALS ;                    # if pipReturnValue == true --> Constraint is staisfied
-            ids:rightOperand "true"^^xsd:boolean ;        # for a certain usage ?duration
+            odrl:rightOperand "true"^^xsd:boolean ;        # for a certain usage ?duration
             ids:pipEndpoint ?askIfEventPipUri ;           # The PIP call for this event, for instance https//pip.com/path/isFIFA_World_Cup_tournaments or https//pip.com/ids?event=FIFA_World_Cup_tournaments
         ] ;
     ]

--- a/examples/contracts-and-usage-policy/templates/NTimesUsageTemplates/N_TIMES_USAGE_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/NTimesUsageTemplates/N_TIMES_USAGE_AGREEMENT_TEMPLATE.jsonld
@@ -16,8 +16,8 @@
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:COUNT" },
-            "ids:operator": { "@id": "idsc:LTEQ" },
+            "odrl:leftOperand": { "@id": "idsc:COUNT" },
+            "odrl:operator": { "@id": "idsc:LTEQ" },
             "ids:rightOperand": { "@id": "?n" },                  // Do not execute the Action more than ?n times.
             "ids:pipEndpoint": "?pipUri"                          // the PIP that counts the access events
           }

--- a/examples/contracts-and-usage-policy/templates/NTimesUsageTemplates/N_TIMES_USAGE_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/NTimesUsageTemplates/N_TIMES_USAGE_AGREEMENT_TEMPLATE.jsonld
@@ -12,7 +12,7 @@
         "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:provider,
         "ids:assignee": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:consumer,
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",

--- a/examples/contracts-and-usage-policy/templates/NTimesUsageTemplates/N_TIMES_USAGE_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/NTimesUsageTemplates/N_TIMES_USAGE_AGREEMENT_TEMPLATE.jsonld
@@ -18,7 +18,7 @@
             "@type:" "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:COUNT" },
             "odrl:operator": { "@id": "idsc:LTEQ" },
-            "ids:rightOperand": { "@id": "?n" },                  // Do not execute the Action more than ?n times.
+            "odrl:rightOperand": { "@id": "?n" },                  // Do not execute the Action more than ?n times.
             "ids:pipEndpoint": "?pipUri"                          // the PIP that counts the access events
           }
         ]

--- a/examples/contracts-and-usage-policy/templates/NTimesUsageTemplates/N_TIMES_USAGE_AGREEMENT_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/NTimesUsageTemplates/N_TIMES_USAGE_AGREEMENT_TEMPLATE.ttl
@@ -29,7 +29,7 @@ idsc:N_TIMES_USAGE_AGREEMENT_TEMPLATE a ids:NotMoreThanNAgreement ;
             a odrl:Constraint ;
             odrl:leftOperand idsc:COUNT ;
             odrl:operator idsc:LTEQ ;
-            ids:rightOperand ?n ;                           # Do not execute the Action more than ?n times.
+            odrl:rightOperand ?n ;                           # Do not execute the Action more than ?n times.
             ids:pipEndpoint ?pipUri ;                       # the PIP that counts the access events
         ] ;
         ( odrl:constraint idsc:CONSTRAINT_TEMPLATE ; )*      # zero or more Constraints

--- a/examples/contracts-and-usage-policy/templates/NTimesUsageTemplates/N_TIMES_USAGE_AGREEMENT_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/NTimesUsageTemplates/N_TIMES_USAGE_AGREEMENT_TEMPLATE.ttl
@@ -24,7 +24,7 @@ idsc:N_TIMES_USAGE_AGREEMENT_TEMPLATE a ids:NotMoreThanNAgreement ;
         odrl:assigner idsc:PARTICIPANT_TEMPLATE ;            # same value as ids:provider
         odrl:assignee idsc:PARTICIPANT_TEMPLATE ;            # same value as ids:consumer
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
             a odrl:Constraint ;
             odrl:leftOperand idsc:COUNT ;

--- a/examples/contracts-and-usage-policy/templates/NTimesUsageTemplates/N_TIMES_USAGE_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/NTimesUsageTemplates/N_TIMES_USAGE_OFFER_TEMPLATE.jsonld
@@ -28,8 +28,8 @@
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:COUNT" },
-            "ids:operator": { "@id": "idsc:LTEQ" },
+            "odrl:leftOperand": { "@id": "idsc:COUNT" },
+            "odrl:operator": { "@id": "idsc:LTEQ" },
             "ids:rightOperand": { "@id": "?n" },                  // Do not execute the Action more than ?n times.
             "ids:pipEndpoint": "?pipUri"                          // the PIP that counts the access events
           }

--- a/examples/contracts-and-usage-policy/templates/NTimesUsageTemplates/N_TIMES_USAGE_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/NTimesUsageTemplates/N_TIMES_USAGE_OFFER_TEMPLATE.jsonld
@@ -30,7 +30,7 @@
             "@type:" "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:COUNT" },
             "odrl:operator": { "@id": "idsc:LTEQ" },
-            "ids:rightOperand": { "@id": "?n" },                  // Do not execute the Action more than ?n times.
+            "odrl:rightOperand": { "@id": "?n" },                  // Do not execute the Action more than ?n times.
             "ids:pipEndpoint": "?pipUri"                          // the PIP that counts the access events
           }
         ]

--- a/examples/contracts-and-usage-policy/templates/NTimesUsageTemplates/N_TIMES_USAGE_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/NTimesUsageTemplates/N_TIMES_USAGE_OFFER_TEMPLATE.jsonld
@@ -24,7 +24,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
         )
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",

--- a/examples/contracts-and-usage-policy/templates/NTimesUsageTemplates/N_TIMES_USAGE_OFFER_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/NTimesUsageTemplates/N_TIMES_USAGE_OFFER_TEMPLATE.ttl
@@ -41,7 +41,7 @@ idsc:N_TIMES_USAGE_OFFER_TEMPLATE a ids:NotMoreThanNOffer ;
             a odrl:Constraint ;
             odrl:leftOperand idsc:COUNT ;
             odrl:operator idsc:LTEQ ;
-            ids:rightOperand ?n ;                           # Do not execute the Action more than ?n times.
+            odrl:rightOperand ?n ;                           # Do not execute the Action more than ?n times.
             ids:pipEndpoint ?pipUri ;                       # the PIP that counts the access events
         ] ;
         ( odrl:constraint idsc:CONSTRAINT_TEMPLATE ; )*      # zero or more Constraints

--- a/examples/contracts-and-usage-policy/templates/NTimesUsageTemplates/N_TIMES_USAGE_OFFER_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/NTimesUsageTemplates/N_TIMES_USAGE_OFFER_TEMPLATE.ttl
@@ -36,7 +36,7 @@ idsc:N_TIMES_USAGE_OFFER_TEMPLATE a ids:NotMoreThanNOffer ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
             a odrl:Constraint ;
             odrl:leftOperand idsc:COUNT ;

--- a/examples/contracts-and-usage-policy/templates/NTimesUsageTemplates/N_TIMES_USAGE_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/NTimesUsageTemplates/N_TIMES_USAGE_REQUEST_TEMPLATE.jsonld
@@ -28,8 +28,8 @@
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:COUNT" },
-            "ids:operator": { "@id": "idsc:LTEQ" },
+            "odrl:leftOperand": { "@id": "idsc:COUNT" },
+            "odrl:operator": { "@id": "idsc:LTEQ" },
             "ids:rightOperand": { "@id": "?n" },                  // Do not execute the Action more than ?n times.
             "ids:pipEndpoint": "?pipUri"                          // the PIP that counts the access events
           }

--- a/examples/contracts-and-usage-policy/templates/NTimesUsageTemplates/N_TIMES_USAGE_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/NTimesUsageTemplates/N_TIMES_USAGE_REQUEST_TEMPLATE.jsonld
@@ -30,7 +30,7 @@
             "@type:" "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:COUNT" },
             "odrl:operator": { "@id": "idsc:LTEQ" },
-            "ids:rightOperand": { "@id": "?n" },                  // Do not execute the Action more than ?n times.
+            "odrl:rightOperand": { "@id": "?n" },                  // Do not execute the Action more than ?n times.
             "ids:pipEndpoint": "?pipUri"                          // the PIP that counts the access events
           }
         ]

--- a/examples/contracts-and-usage-policy/templates/NTimesUsageTemplates/N_TIMES_USAGE_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/NTimesUsageTemplates/N_TIMES_USAGE_REQUEST_TEMPLATE.jsonld
@@ -24,7 +24,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
         )
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",

--- a/examples/contracts-and-usage-policy/templates/NTimesUsageTemplates/N_TIMES_USAGE_REQUEST_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/NTimesUsageTemplates/N_TIMES_USAGE_REQUEST_TEMPLATE.ttl
@@ -36,7 +36,7 @@ idsc:N_TIMES_USAGE_REQUEST_TEMPLATE a ids:NotMoreThanNRequest ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
             a odrl:Constraint ;
             odrl:leftOperand idsc:COUNT ;

--- a/examples/contracts-and-usage-policy/templates/NTimesUsageTemplates/N_TIMES_USAGE_REQUEST_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/NTimesUsageTemplates/N_TIMES_USAGE_REQUEST_TEMPLATE.ttl
@@ -41,7 +41,7 @@ idsc:N_TIMES_USAGE_REQUEST_TEMPLATE a ids:NotMoreThanNRequest ;
             a odrl:Constraint ;
             odrl:leftOperand idsc:COUNT ;
             odrl:operator idsc:LTEQ ;
-            ids:rightOperand ?n ;                           # Do not execute the Action more than ?n times.
+            odrl:rightOperand ?n ;                           # Do not execute the Action more than ?n times.
             ids:pipEndpoint ?pipUri ;                       # the PIP that counts the access events
         ] ;
         ( odrl:constraint idsc:CONSTRAINT_TEMPLATE ; )*      # zero or more Constraints

--- a/examples/contracts-and-usage-policy/templates/ObligationTemplates/OBLIGATION_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/ObligationTemplates/OBLIGATION_TEMPLATE.jsonld
@@ -8,6 +8,6 @@
     "@id": "?URI",
     "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),
     "ids:assignee": (idsc:PARTICIPANT_TEMPLATE),
-    "ids:action": (idsc:ACTION_TEMPLATE)
+    "odrl:action": (idsc:ACTION_TEMPLATE)
     (, "ids:constraint": (idsc:CONSTRAINT_TEMPLATE) )*    // zero or more Constraints
 }

--- a/examples/contracts-and-usage-policy/templates/ObligationTemplates/OBLIGATION_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/ObligationTemplates/OBLIGATION_TEMPLATE.ttl
@@ -17,6 +17,6 @@
 idsc:OBLIGATION_TEMPLATE a odrl:Duty ;
     odrl:assigner idsc:PARTICIPANT_TEMPLATE ;
     odrl:assignee idsc:PARTICIPANT_TEMPLATE ;
-    ids:action idsc:ACTION_TEMPLATE ;
+    odrl:action idsc:ACTION_TEMPLATE ;
     [ odrl:constraint idsc:CONSTRAINT_TEMPLATE ; ]*      # zero or more Constraints
 .

--- a/examples/contracts-and-usage-policy/templates/ParticipantTemplates/PARTICIPANT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/ParticipantTemplates/PARTICIPANT_TEMPLATE.jsonld
@@ -18,7 +18,7 @@
         "@type": "ids:Constraint",                                  // Define a collection of data objects which, for instance, all have an explicit attribute "color":"blue"
         "odrl:leftOperand": { "@id": "?IdscLeftOperand" },           // The feature of interest, for instance ?IdscLeftOperand := idsc:PATH
         "odrl:operator": { "@id": "?IdscBinaryOperator" },           // The kind of check, which shall be executed on the feature of interest, for instance ?IdscBinaryOperator := idsc:STRING_EQ
-        "ids:rightOperand": { "@id": "?Value" }                     // The value expression all members of this collection have to share, for instance ?Value := "blue"
+        "odrl:rightOperand": { "@id": "?Value" }                     // The value expression all members of this collection have to share, for instance ?Value := "blue"
         (, "ids:pipEndpoint": { "@id": "?AttributeLocation"} )?     // A URI or path expression to the target attribute, ?AttributeLocation := "//color"
         (, "ids:unit": { "@id": "?Unit" } )?                        // A unit which may further explain the ?Value, for instance <http://dbpedia.org/resource/Color>.
       }
@@ -37,7 +37,7 @@
                 "@type": "ids:Constraint",
                 "odrl:leftOperand": { "@id": "?IdscLeftOperand" },
                 "odrl:operator": { "@id": "?IdsBinaryOperator" },
-                "ids:rightOperand": { "@id": "?Value" }
+                "odrl:rightOperand": { "@id": "?Value" }
                 (, "ids:pipEndpoint": { "@id": "?AttributeLocation" } )?
                 (, "ids:unit": { "@id": "?Unit" } )?
               }

--- a/examples/contracts-and-usage-policy/templates/ParticipantTemplates/PARTICIPANT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/ParticipantTemplates/PARTICIPANT_TEMPLATE.jsonld
@@ -16,8 +16,8 @@
     "ids:participantRefinement": [
       {
         "@type": "ids:Constraint",                                  // Define a collection of data objects which, for instance, all have an explicit attribute "color":"blue"
-        "ids:leftOperand": { "@id": "?IdscLeftOperand" },           // The feature of interest, for instance ?IdscLeftOperand := idsc:PATH
-        "ids:operator": { "@id": "?IdscBinaryOperator" },           // The kind of check, which shall be executed on the feature of interest, for instance ?IdscBinaryOperator := idsc:STRING_EQ
+        "odrl:leftOperand": { "@id": "?IdscLeftOperand" },           // The feature of interest, for instance ?IdscLeftOperand := idsc:PATH
+        "odrl:operator": { "@id": "?IdscBinaryOperator" },           // The kind of check, which shall be executed on the feature of interest, for instance ?IdscBinaryOperator := idsc:STRING_EQ
         "ids:rightOperand": { "@id": "?Value" }                     // The value expression all members of this collection have to share, for instance ?Value := "blue"
         (, "ids:pipEndpoint": { "@id": "?AttributeLocation"} )?     // A URI or path expression to the target attribute, ?AttributeLocation := "//color"
         (, "ids:unit": { "@id": "?Unit" } )?                        // A unit which may further explain the ?Value, for instance <http://dbpedia.org/resource/Color>.
@@ -35,8 +35,8 @@
             (
               {
                 "@type": "ids:Constraint",
-                "ids:leftOperand": { "@id": "?IdscLeftOperand" },
-                "ids:operator": { "@id": "?IdsBinaryOperator" },
+                "odrl:leftOperand": { "@id": "?IdscLeftOperand" },
+                "odrl:operator": { "@id": "?IdsBinaryOperator" },
                 "ids:rightOperand": { "@id": "?Value" }
                 (, "ids:pipEndpoint": { "@id": "?AttributeLocation" } )?
                 (, "ids:unit": { "@id": "?Unit" } )?

--- a/examples/contracts-and-usage-policy/templates/ParticipantTemplates/PARTICIPANT_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/ParticipantTemplates/PARTICIPANT_TEMPLATE.ttl
@@ -28,7 +28,7 @@
             a odrl:Constraint ;                              # Define a collection of data objects which, for instance all have an explicit attribute "role":"ADMIN"
             odrl:leftOperand ?IdscLeftOperand ;              # The feature of interest, for instance ?IdscLeftOperand := idsc:PATH
             odrl:operator ?IdscBinaryOperator ;              # The kind of check, which shall be executed on the feature of interest, for instance ?IdscBinaryOperator := idsc:STRING_EQ
-            ids:rightOperand ?Value ;                       # The value expression all members of this collection have to share, for instance ?Value := "ADMIN"
+            odrl:rightOperand ?Value ;                       # The value expression all members of this collection have to share, for instance ?Value := "ADMIN"
             ( ids:pipEndpoint ?AttributeLocation ; )?   # A URI or path expression to the target attribute, ?AttributeLocation := "//role"
             ( odrl:unit ?Unit ; )?                           # A unit which may further explain the ?Value
         ]
@@ -44,7 +44,7 @@
                         a odrl:Constraint ;
                         odrl:leftOperand ?IdscLeftOperand ;
                         odrl:operator ?IdsBinaryOperator ;
-                        ids:rightOperand ?Value ;
+                        odrl:rightOperand ?Value ;
                         ( ids:pipEndpoint ?AttributeLocation ; )?
                         ( odrl:unit ?Unit ; )?
                     ){2,} # at least two constraints

--- a/examples/contracts-and-usage-policy/templates/PermissionTemplates/AGREEMENT_PERMISSION_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/PermissionTemplates/AGREEMENT_PERMISSION_TEMPLATE.jsonld
@@ -9,7 +9,7 @@
     "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),
     "ids:assignee": (idsc:PARTICIPANT_TEMPLATE),
     "ids:target": (idsc:ASSET_TEMPLATE),                    // A Permission has a target Asset
-    "ids:action": (idsc:ACTION_TEMPLATE)
+    "odrl:action": (idsc:ACTION_TEMPLATE)
     (, "ids:constraint": (idsc:CONSTRAINT_TEMPLATE) )*      // zero or more Constraints
     (, "ids:preDuty": (idsc:OBLIGATION_TEMPLATE) )*   // zero or more Obligations which need to be fulfilled before the Usage event
     (, "ids:postDuty": (idsc:OBLIGATION_TEMPLATE) )*  // zero or more Obligations which have to be fulfilled after the Usage event

--- a/examples/contracts-and-usage-policy/templates/PermissionTemplates/AGREEMENT_PERMISSION_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/PermissionTemplates/AGREEMENT_PERMISSION_TEMPLATE.ttl
@@ -16,7 +16,7 @@ idsc:AGREEMENT_PERMISSION_TEMPLATE a odrl:Permission ;
     odrl:assigner idsc:PARTICIPANT_TEMPLATE ;
     odrl:assignee idsc:PARTICIPANT_TEMPLATE ;
     ids:target idsc:ASSET_TEMPLATE ;                    # A Permission has a target Asset.
-    ids:action idsc:ACTION_TEMPLATE ;
+    odrl:action idsc:ACTION_TEMPLATE ;
     [ odrl:constraint idsc:CONSTRAINT_TEMPLATE ; ]*      # zero or more Constraints
     [ ids:preDuty idsc:OBLIGATION_TEMPLATE ; ]*   # zero or more Obligations which need to be fulfilled before the Usage event
     [ ids:postDuty idsc:OBLIGATION_TEMPLATE ; ]*  # zero or more Obligations which have to be fulfilled after the Usage event

--- a/examples/contracts-and-usage-policy/templates/PermissionTemplates/OFFER_PERMISSION_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/PermissionTemplates/OFFER_PERMISSION_TEMPLATE.jsonld
@@ -15,7 +15,7 @@
         "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )
     )
     "ids:target": (idsc:ASSET_TEMPLATE),                    // A Permission has a target Asset
-    "ids:action": (idsc:ACTION_TEMPLATE)
+    "odrl:action": (idsc:ACTION_TEMPLATE)
     (, "ids:constraint": (idsc:CONSTRAINT_TEMPLATE) )*      // zero or more Constraints
     (, "ids:preDuty": (idsc:OBLIGATION_TEMPLATE) )*   // zero or more Obligations which need to be fulfilled before the Usage event
     (, "ids:postDuty": (idsc:OBLIGATION_TEMPLATE) )*  // zero or more Obligations which have to be fulfilled after the Usage event

--- a/examples/contracts-and-usage-policy/templates/PermissionTemplates/OFFER_PERMISSION_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/PermissionTemplates/OFFER_PERMISSION_TEMPLATE.ttl
@@ -22,7 +22,7 @@ idsc:OFFER_PERMISSION_TEMPLATE a odrl:Permission ;
        odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)
     )
     ids:target idsc:ASSET_TEMPLATE ;                    # A Permission has a target Asset.
-    ids:action idsc:ACTION_TEMPLATE ;
+    odrl:action idsc:ACTION_TEMPLATE ;
     [ odrl:constraint idsc:CONSTRAINT_TEMPLATE ; ]*      # zero or more Constraints
     [ ids:preDuty idsc:OBLIGATION_TEMPLATE ; ]*   # zero or more Obligations which need to be fulfilled before the Usage event
     [ ids:postDuty idsc:OBLIGATION_TEMPLATE ; ]*  # zero or more Obligations which have to be fulfilled after the Usage event

--- a/examples/contracts-and-usage-policy/templates/PermissionTemplates/REQUEST_PERMISSION_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/PermissionTemplates/REQUEST_PERMISSION_TEMPLATE.jsonld
@@ -15,7 +15,7 @@
         "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )
     )
     "ids:target": (idsc:ASSET_TEMPLATE),                    // A Permission has a target Asset
-    "ids:action": (idsc:ACTION_TEMPLATE)
+    "odrl:action": (idsc:ACTION_TEMPLATE)
     (, "ids:constraint": (idsc:CONSTRAINT_TEMPLATE) )*      // zero or more Constraints
     (, "ids:preDuty": (idsc:OBLIGATION_TEMPLATE) )*   // zero or more Obligations which need to be fulfilled before the Usage event
     (, "ids:postDuty": (idsc:OBLIGATION_TEMPLATE) )*  // zero or more Obligations which have to be fulfilled after the Usage event

--- a/examples/contracts-and-usage-policy/templates/PermissionTemplates/REQUEST_PERMISSION_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/PermissionTemplates/REQUEST_PERMISSION_TEMPLATE.ttl
@@ -22,7 +22,7 @@ idsc:REQUEST_PERMISSION_TEMPLATE a odrl:Permission ;
        odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)
     )
     ids:target idsc:ASSET_TEMPLATE ;
-    ids:action idsc:ACTION_TEMPLATE ;
+    odrl:action idsc:ACTION_TEMPLATE ;
     [ odrl:constraint idsc:CONSTRAINT_TEMPLATE ; ]*      # zero or more Constraints
     [ ids:preDuty idsc:OBLIGATION_TEMPLATE ; ]*   # zero or more Obligations which need to be fulfilled before the Usage event
     [ ids:postDuty idsc:OBLIGATION_TEMPLATE ; ]*  # zero or more Obligations which have to be fulfilled after the Usage event

--- a/examples/contracts-and-usage-policy/templates/PurposeRestrictedUsageTemplates/PURPOSE_RESTRICTED_USAGE_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/PurposeRestrictedUsageTemplates/PURPOSE_RESTRICTED_USAGE_AGREEMENT_TEMPLATE.jsonld
@@ -12,7 +12,7 @@
         "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:provider,
         "ids:assignee": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:consumer,
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",

--- a/examples/contracts-and-usage-policy/templates/PurposeRestrictedUsageTemplates/PURPOSE_RESTRICTED_USAGE_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/PurposeRestrictedUsageTemplates/PURPOSE_RESTRICTED_USAGE_AGREEMENT_TEMPLATE.jsonld
@@ -16,8 +16,8 @@
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:PURPOSE" },
-            "ids:operator": { "@id": "idsc:SAME_AS" },
+            "odrl:leftOperand": { "@id": "idsc:PURPOSE" },
+            "odrl:operator": { "@id": "idsc:SAME_AS" },
             "ids:rightOperandReference": { "@id": "?PurposeURI" },
             "ids:pipEndpoint": { "@id": "?pipUri"}                  // A reference to a Policy Information Point endpoint (might be only locally accessible), which knows about the usage purpose.
           }

--- a/examples/contracts-and-usage-policy/templates/PurposeRestrictedUsageTemplates/PURPOSE_RESTRICTED_USAGE_AGREEMENT_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/PurposeRestrictedUsageTemplates/PURPOSE_RESTRICTED_USAGE_AGREEMENT_TEMPLATE.ttl
@@ -25,7 +25,7 @@ idsc:PURPOSE_RESTRICTED_USAGE_AGREEMENT_TEMPLATE a ids:PurposeAgreement ;
         odrl:assigner idsc:PARTICIPANT_TEMPLATE ;
         odrl:assignee idsc:PARTICIPANT_TEMPLATE ;
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
             a odrl:Constraint ;
             odrl:leftOperand idsc:PURPOSE ;

--- a/examples/contracts-and-usage-policy/templates/PurposeRestrictedUsageTemplates/PURPOSE_RESTRICTED_USAGE_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/PurposeRestrictedUsageTemplates/PURPOSE_RESTRICTED_USAGE_OFFER_TEMPLATE.jsonld
@@ -28,8 +28,8 @@
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:PURPOSE" },
-            "ids:operator": { "@id": "idsc:SAME_AS" },
+            "odrl:leftOperand": { "@id": "idsc:PURPOSE" },
+            "odrl:operator": { "@id": "idsc:SAME_AS" },
             "ids:rightOperandReference": { "@id": "?PurposeURI" },
             "ids:pipEndpoint": { "@id": "?pipUri"}                  // A reference to a Policy Information Point endpoint (might be only locally accessible), which knows about the usage purpose.
           }

--- a/examples/contracts-and-usage-policy/templates/PurposeRestrictedUsageTemplates/PURPOSE_RESTRICTED_USAGE_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/PurposeRestrictedUsageTemplates/PURPOSE_RESTRICTED_USAGE_OFFER_TEMPLATE.jsonld
@@ -24,7 +24,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
         )
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",

--- a/examples/contracts-and-usage-policy/templates/PurposeRestrictedUsageTemplates/PURPOSE_RESTRICTED_USAGE_OFFER_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/PurposeRestrictedUsageTemplates/PURPOSE_RESTRICTED_USAGE_OFFER_TEMPLATE.ttl
@@ -37,7 +37,7 @@ idsc:PURPOSE_RESTRICTED_USAGE_OFFER_TEMPLATE a ids:PurposeOffer ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
             a odrl:Constraint ;
             odrl:leftOperand idsc:PURPOSE ;

--- a/examples/contracts-and-usage-policy/templates/PurposeRestrictedUsageTemplates/PURPOSE_RESTRICTED_USAGE_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/PurposeRestrictedUsageTemplates/PURPOSE_RESTRICTED_USAGE_REQUEST_TEMPLATE.jsonld
@@ -28,8 +28,8 @@
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:PURPOSE" },
-            "ids:operator": { "@id": "idsc:SAME_AS" },
+            "odrl:leftOperand": { "@id": "idsc:PURPOSE" },
+            "odrl:operator": { "@id": "idsc:SAME_AS" },
             "ids:rightOperandReference": { "@id": "?PurposeURI" },
             "ids:pipEndpoint": { "@id": "?pipUri"}                  // A reference to a Policy Information Point endpoint (might be only locally accessible), which knows about the usage purpose.
           }

--- a/examples/contracts-and-usage-policy/templates/PurposeRestrictedUsageTemplates/PURPOSE_RESTRICTED_USAGE_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/PurposeRestrictedUsageTemplates/PURPOSE_RESTRICTED_USAGE_REQUEST_TEMPLATE.jsonld
@@ -24,7 +24,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
         )
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",

--- a/examples/contracts-and-usage-policy/templates/PurposeRestrictedUsageTemplates/PURPOSE_RESTRICTED_USAGE_REQUEST_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/PurposeRestrictedUsageTemplates/PURPOSE_RESTRICTED_USAGE_REQUEST_TEMPLATE.ttl
@@ -37,7 +37,7 @@ idsc:PURPOSE_RESTRICTED_USAGE_REQUEST_TEMPLATE a ids:PurposeRequest ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
             a odrl:Constraint ;
             odrl:leftOperand idsc:PURPOSE ;

--- a/examples/contracts-and-usage-policy/templates/RentalTemplates/RENTAL_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/RentalTemplates/RENTAL_AGREEMENT_TEMPLATE.jsonld
@@ -17,15 +17,15 @@
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:STATE" },
-            "ids:operator": { "@id": "idsc:NOT" },
+            "odrl:leftOperand": { "@id": "idsc:STATE" },
+            "odrl:operator": { "@id": "idsc:NOT" },
             "ids:rightOperand": { "@id": "?terminationState" }    // An entity expressing the (final) state that the contract has been terminated by either one of the involved parties.
             (, "ids:pipEndpoint": { "@id": "?pipUri" } )?         // The location where to find this state.
           },
           {
             "@type:" "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:STATE" },
-            "ids:operator": { "@id": "idsc:NOT" },
+            "odrl:leftOperand": { "@id": "idsc:STATE" },
+            "odrl:operator": { "@id": "idsc:NOT" },
             "ids:rightOperand": { "@id": "?terminationState" }    // An entity expressing the (final) state that the contract has been terminated by either one of the involved parties.
             (, "ids:pipEndpoint": { "@id": "?pipUri" } )?         // The location where to find this state.
           }
@@ -39,8 +39,8 @@
                 "ids:includedIn": { "@id": "idsc:COMPENSATE" },
                 "ids:actionRefinement": [{
                     "@type": "ids:Constraint",
-                    "ids:leftOperand": { "@id": "idsc:PAYMENT" },
-                    "ids:operator": { "@id": "idsc:EQ" },
+                    "odrl:leftOperand": { "@id": "idsc:PAYMENT" },
+                    "odrl:operator": { "@id": "idsc:EQ" },
 
                     "ids:rightOperand": {
                         "@value": "?fee",
@@ -53,8 +53,8 @@
             "ids:constraint": [
               {
                 "@type": { "@id": "ids:Constraint" },
-                "ids:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
-                "ids:operator": { "@id": "idsc:AFTER" },
+                "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
+                "odrl:operator": { "@id": "idsc:AFTER" },
                 "ids:rightOperand": {
                     "@value": "?duration",                        // for a certain usage ?duration
                     "@type": "http://www.w3.org/2001/XMLSchema#duration"

--- a/examples/contracts-and-usage-policy/templates/RentalTemplates/RENTAL_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/RentalTemplates/RENTAL_AGREEMENT_TEMPLATE.jsonld
@@ -19,14 +19,14 @@
             "@type:" "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:STATE" },
             "odrl:operator": { "@id": "idsc:NOT" },
-            "ids:rightOperand": { "@id": "?terminationState" }    // An entity expressing the (final) state that the contract has been terminated by either one of the involved parties.
+            "odrl:rightOperand": { "@id": "?terminationState" }    // An entity expressing the (final) state that the contract has been terminated by either one of the involved parties.
             (, "ids:pipEndpoint": { "@id": "?pipUri" } )?         // The location where to find this state.
           },
           {
             "@type:" "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:STATE" },
             "odrl:operator": { "@id": "idsc:NOT" },
-            "ids:rightOperand": { "@id": "?terminationState" }    // An entity expressing the (final) state that the contract has been terminated by either one of the involved parties.
+            "odrl:rightOperand": { "@id": "?terminationState" }    // An entity expressing the (final) state that the contract has been terminated by either one of the involved parties.
             (, "ids:pipEndpoint": { "@id": "?pipUri" } )?         // The location where to find this state.
           }
         ] ,
@@ -42,7 +42,7 @@
                     "odrl:leftOperand": { "@id": "idsc:PAYMENT" },
                     "odrl:operator": { "@id": "idsc:EQ" },
 
-                    "ids:rightOperand": {
+                    "odrl:rightOperand": {
                         "@value": "?fee",
                         "@type": "http://www.w3.org/2001/XMLSchema#double"
                     },
@@ -55,7 +55,7 @@
                 "@type": { "@id": "ids:Constraint" },
                 "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
                 "odrl:operator": { "@id": "idsc:AFTER" },
-                "ids:rightOperand": {
+                "odrl:rightOperand": {
                     "@value": "?duration",                        // for a certain usage ?duration
                     "@type": "http://www.w3.org/2001/XMLSchema#duration"
                 }

--- a/examples/contracts-and-usage-policy/templates/RentalTemplates/RENTAL_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/RentalTemplates/RENTAL_AGREEMENT_TEMPLATE.jsonld
@@ -13,7 +13,7 @@
         "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:provider,
         "ids:assignee": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:consumer,
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",
@@ -34,8 +34,8 @@
             "@type": "ids:Duty",
             "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),          // same value as ids:provider
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE),          // same value as ids:consumer
-            "ids:action": {
-                "@type": "ids:Action",
+            "odrl:action": {
+                "@type": "odrl:Action",
                 "ids:includedIn": { "@id": "idsc:COMPENSATE" },
                 "ids:actionRefinement": [{
                     "@type": "ids:Constraint",

--- a/examples/contracts-and-usage-policy/templates/RentalTemplates/RENTAL_AGREEMENT_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/RentalTemplates/RENTAL_AGREEMENT_TEMPLATE.ttl
@@ -30,7 +30,7 @@ idsc:RENTAL_AGREEMENT_TEMPLATE a ids:RentalAgreement ;
             a odrl:Constraint ;
             odrl:leftOperand idsc:STATE ;
             odrl:operator idsc:NOT ;
-            ids:rightOperand ?terminationState ;            # An entity expressing the (final) state that the contract has been terminated by either one of the involved parties.
+            odrl:rightOperand ?terminationState ;            # An entity expressing the (final) state that the contract has been terminated by either one of the involved parties.
             ( ids:pipEndpoint ?pipUri ; )?                  # The location where to find this state.
         ] ;
         ids:preDuty [
@@ -44,7 +44,7 @@ idsc:RENTAL_AGREEMENT_TEMPLATE a ids:RentalAgreement ;
                     a odrl:Constraint ;
                     odrl:leftOperand idsc:PAY_AMOUNT ;
                     odrl:operator idsc:EQ ;
-                    ids:rightOperand "?fee"^^xsd:double ;   # pay the ?fee
+                    odrl:rightOperand "?fee"^^xsd:double ;   # pay the ?fee
                     odrl:unit ?currency ;
                     ( ids:pipEndpoint ?pipUri ; )?
                 ]
@@ -53,7 +53,7 @@ idsc:RENTAL_AGREEMENT_TEMPLATE a ids:RentalAgreement ;
                 a odrl:Constraint ;
                 odrl:leftOperand idsc:POLICY_EVALUATION_TIME ;
                 odrl:operator idsc:AFTER ;
-                ids:rightOperand ?duration ;                # for a certain usage ?duration
+                odrl:rightOperand ?duration ;                # for a certain usage ?duration
             ]
         ] ;
         ( odrl:constraint idsc:CONSTRAINT_TEMPLATE ; )*      # zero or more Constraints

--- a/examples/contracts-and-usage-policy/templates/RentalTemplates/RENTAL_AGREEMENT_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/RentalTemplates/RENTAL_AGREEMENT_TEMPLATE.ttl
@@ -25,7 +25,7 @@ idsc:RENTAL_AGREEMENT_TEMPLATE a ids:RentalAgreement ;
         odrl:assigner idsc:PARTICIPANT_TEMPLATE ;            # same value as ids:provider
         odrl:assignee idsc:PARTICIPANT_TEMPLATE ;            # same value as ids:consumer
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
             a odrl:Constraint ;
             odrl:leftOperand idsc:STATE ;
@@ -37,7 +37,7 @@ idsc:RENTAL_AGREEMENT_TEMPLATE a ids:RentalAgreement ;
             a odrl:Duty ;
             odrl:assigner idsc:PARTICIPANT_TEMPLATE ;        # same value as ids:provider
             odrl:assignee idsc:PARTICIPANT_TEMPLATE ;        # same value as ids:consumer
-            ids:action [
+            odrl:action [
                 a odrl:Action ;
                 odrl:includedIn idsc:COMPENSATE ;
                 ids:actionRefinement [

--- a/examples/contracts-and-usage-policy/templates/RentalTemplates/RENTAL_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/RentalTemplates/RENTAL_OFFER_TEMPLATE.jsonld
@@ -30,7 +30,7 @@
             "@type:" "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:STATE" },
             "odrl:operator": { "@id": "idsc:NOT" },
-            "ids:rightOperand": { "@id": "?terminationState" }    // An entity expressing the (final) state that the contract has been terminated by either one of the involved parties.
+            "odrl:rightOperand": { "@id": "?terminationState" }    // An entity expressing the (final) state that the contract has been terminated by either one of the involved parties.
             (, "ids:pipEndpoint": { "@id": "?pipUri" } )?         // The location where to find this state.
           }
         ] ,
@@ -51,7 +51,7 @@
                     "@type": "ids:Constraint",
                     "odrl:leftOperand": { "@id": "idsc:PAY_AMOUNT" },
                     "odrl:operator": { "@id": "idsc:EQ" },
-                    "ids:rightOperand": {
+                    "odrl:rightOperand": {
                         "@value": "?fee",
                         "@type": "http://www.w3.org/2001/XMLSchema#double"
                     },
@@ -64,7 +64,7 @@
                 "@type": { "@id": "ids:Constraint" },
                 "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
                 "odrl:operator": { "@id": "idsc:AFTER" },
-                "ids:rightOperand": {
+                "odrl:rightOperand": {
                     "@value": "?duration",                        // for a certain usage ?duration
                     "@type": "http://www.w3.org/2001/XMLSchema#duration"
                 }

--- a/examples/contracts-and-usage-policy/templates/RentalTemplates/RENTAL_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/RentalTemplates/RENTAL_OFFER_TEMPLATE.jsonld
@@ -24,7 +24,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
         )
         "ids:target": (idsc:TARGET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",
@@ -44,8 +44,8 @@
               ( "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),           // same value as ids:provider
                 "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
             )
-            "ids:action": {
-                "@type": "ids:Action",
+            "odrl:action": {
+                "@type": "odrl:Action",
                 "ids:includedIn": { "@id": "idsc:COMPENSATE" },
                 "ids:actionRefinement": {
                     "@type": "ids:Constraint",

--- a/examples/contracts-and-usage-policy/templates/RentalTemplates/RENTAL_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/RentalTemplates/RENTAL_OFFER_TEMPLATE.jsonld
@@ -28,8 +28,8 @@
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:STATE" },
-            "ids:operator": { "@id": "idsc:NOT" },
+            "odrl:leftOperand": { "@id": "idsc:STATE" },
+            "odrl:operator": { "@id": "idsc:NOT" },
             "ids:rightOperand": { "@id": "?terminationState" }    // An entity expressing the (final) state that the contract has been terminated by either one of the involved parties.
             (, "ids:pipEndpoint": { "@id": "?pipUri" } )?         // The location where to find this state.
           }
@@ -49,8 +49,8 @@
                 "ids:includedIn": { "@id": "idsc:COMPENSATE" },
                 "ids:actionRefinement": {
                     "@type": "ids:Constraint",
-                    "ids:leftOperand": { "@id": "idsc:PAY_AMOUNT" },
-                    "ids:operator": { "@id": "idsc:EQ" },
+                    "odrl:leftOperand": { "@id": "idsc:PAY_AMOUNT" },
+                    "odrl:operator": { "@id": "idsc:EQ" },
                     "ids:rightOperand": {
                         "@value": "?fee",
                         "@type": "http://www.w3.org/2001/XMLSchema#double"
@@ -62,8 +62,8 @@
             "ids:constraint": [
               {
                 "@type": { "@id": "ids:Constraint" },
-                "ids:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
-                "ids:operator": { "@id": "idsc:AFTER" },
+                "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
+                "odrl:operator": { "@id": "idsc:AFTER" },
                 "ids:rightOperand": {
                     "@value": "?duration",                        // for a certain usage ?duration
                     "@type": "http://www.w3.org/2001/XMLSchema#duration"

--- a/examples/contracts-and-usage-policy/templates/RentalTemplates/RENTAL_OFFER_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/RentalTemplates/RENTAL_OFFER_TEMPLATE.ttl
@@ -37,7 +37,7 @@ idsc:RENTAL_OFFER_TEMPLATE a ids:RentalOffer ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
             a odrl:Constraint ;
             odrl:leftOperand idsc:STATE ;

--- a/examples/contracts-and-usage-policy/templates/RentalTemplates/RENTAL_OFFER_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/RentalTemplates/RENTAL_OFFER_TEMPLATE.ttl
@@ -42,7 +42,7 @@ idsc:RENTAL_OFFER_TEMPLATE a ids:RentalOffer ;
             a odrl:Constraint ;
             odrl:leftOperand idsc:STATE ;
             odrl:operator idsc:NOT ;
-            ids:rightOperand ?terminationState ;            # An entity expressing the (final) state that the contract has been terminated by either one of the involved parties.
+            odrl:rightOperand ?terminationState ;            # An entity expressing the (final) state that the contract has been terminated by either one of the involved parties.
             ( ids:pipEndpoint ?pipUri ; )?                  # The location where to find this state.
         ] ;
         ids:preDuty [
@@ -62,7 +62,7 @@ idsc:RENTAL_OFFER_TEMPLATE a ids:RentalOffer ;
                     a odrl:Constraint ;
                     odrl:leftOperand idsc:PAY_AMOUNT ;
                     odrl:operator idsc:EQ ;
-                    ids:rightOperand "?fee"^^xsd:double ;   # pay the ?fee
+                    odrl:rightOperand "?fee"^^xsd:double ;   # pay the ?fee
                     odrl:unit ?currency ;
                     ( ids:pipEndpoint ?pipUri ; )?
                 ]
@@ -71,7 +71,7 @@ idsc:RENTAL_OFFER_TEMPLATE a ids:RentalOffer ;
                 a odrl:Constraint ;
                 odrl:leftOperand idsc:POLICY_EVALUATION_TIME ;
                 odrl:operator idsc:AFTER ;
-                ids:rightOperand ?duration ;                # for a certain usage ?duration
+                odrl:rightOperand ?duration ;                # for a certain usage ?duration
             ]
         ] ;
         ( odrl:constraint idsc:CONSTRAINT_TEMPLATE ; )*      # zero or more Constraints

--- a/examples/contracts-and-usage-policy/templates/RentalTemplates/RENTAL_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/RentalTemplates/RENTAL_REQUEST_TEMPLATE.jsonld
@@ -30,7 +30,7 @@
             "@type:" "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:STATE" },
             "odrl:operator": { "@id": "idsc:NOT" },
-            "ids:rightOperand": { "@id": "?terminationState" }    // An entity expressing the (final) state that the contract has been terminated by either one of the involved parties.
+            "odrl:rightOperand": { "@id": "?terminationState" }    // An entity expressing the (final) state that the contract has been terminated by either one of the involved parties.
             (, "ids:pipEndpoint": { "@id": "?pipUri" } )?         // The location where to find this state.
           }
         ] ,
@@ -51,7 +51,7 @@
                     "@type": "ids:Constraint",
                     "odrl:leftOperand": { "@id": "idsc:PAY_AMOUNT" },
                     "odrl:operator": { "@id": "idsc:EQ" },
-                    "ids:rightOperand": {
+                    "odrl:rightOperand": {
                         "@value": "?fee",
                         "@type": "http://www.w3.org/2001/XMLSchema#double"
                     },
@@ -64,7 +64,7 @@
                 "@type": { "@id": "ids:Constraint" },
                 "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
                 "odrl:operator": { "@id": "idsc:AFTER" },
-                "ids:rightOperand": {
+                "odrl:rightOperand": {
                     "@value": "?duration",                        // for a certain usage ?duration
                     "@type": "http://www.w3.org/2001/XMLSchema#duration"
                 }

--- a/examples/contracts-and-usage-policy/templates/RentalTemplates/RENTAL_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/RentalTemplates/RENTAL_REQUEST_TEMPLATE.jsonld
@@ -24,7 +24,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
         )
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",
@@ -44,8 +44,8 @@
               ( "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),           // same value as ids:provider
                 "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
             )
-            "ids:action": {
-                "@type": "ids:Action",
+            "odrl:action": {
+                "@type": "odrl:Action",
                 "ids:includedIn": { "@id": "idsc:COMPENSATE" },
                 "ids:actionRefinement": {
                     "@type": "ids:Constraint",

--- a/examples/contracts-and-usage-policy/templates/RentalTemplates/RENTAL_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/RentalTemplates/RENTAL_REQUEST_TEMPLATE.jsonld
@@ -28,8 +28,8 @@
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:STATE" },
-            "ids:operator": { "@id": "idsc:NOT" },
+            "odrl:leftOperand": { "@id": "idsc:STATE" },
+            "odrl:operator": { "@id": "idsc:NOT" },
             "ids:rightOperand": { "@id": "?terminationState" }    // An entity expressing the (final) state that the contract has been terminated by either one of the involved parties.
             (, "ids:pipEndpoint": { "@id": "?pipUri" } )?         // The location where to find this state.
           }
@@ -49,8 +49,8 @@
                 "ids:includedIn": { "@id": "idsc:COMPENSATE" },
                 "ids:actionRefinement": {
                     "@type": "ids:Constraint",
-                    "ids:leftOperand": { "@id": "idsc:PAY_AMOUNT" },
-                    "ids:operator": { "@id": "idsc:EQ" },
+                    "odrl:leftOperand": { "@id": "idsc:PAY_AMOUNT" },
+                    "odrl:operator": { "@id": "idsc:EQ" },
                     "ids:rightOperand": {
                         "@value": "?fee",
                         "@type": "http://www.w3.org/2001/XMLSchema#double"
@@ -62,8 +62,8 @@
             "ids:constraint": [
               {
                 "@type": { "@id": "ids:Constraint" },
-                "ids:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
-                "ids:operator": { "@id": "idsc:AFTER" },
+                "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
+                "odrl:operator": { "@id": "idsc:AFTER" },
                 "ids:rightOperand": {
                     "@value": "?duration",                        // for a certain usage ?duration
                     "@type": "http://www.w3.org/2001/XMLSchema#duration"

--- a/examples/contracts-and-usage-policy/templates/RentalTemplates/RENTAL_REQUEST_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/RentalTemplates/RENTAL_REQUEST_TEMPLATE.ttl
@@ -42,7 +42,7 @@ idsc:RENTAL_REQUEST_TEMPLATE a ids:RentalRequest ;
             a odrl:Constraint ;
             odrl:leftOperand idsc:STATE ;
             odrl:operator idsc:NOT ;
-            ids:rightOperand ?terminationState ;            # An entity expressing the (final) state that the contract has been terminated by either one of the involved parties.
+            odrl:rightOperand ?terminationState ;            # An entity expressing the (final) state that the contract has been terminated by either one of the involved parties.
             ( ids:pipEndpoint ?pipUri ; )?                  # The location where to find this state.
         ] ;
         ids:preDuty [
@@ -62,7 +62,7 @@ idsc:RENTAL_REQUEST_TEMPLATE a ids:RentalRequest ;
                     a odrl:Constraint ;
                     odrl:leftOperand idsc:PAY_AMOUNT ;
                     odrl:operator idsc:EQ ;
-                    ids:rightOperand "?fee"^^xsd:double ;   # pay the ?fee
+                    odrl:rightOperand "?fee"^^xsd:double ;   # pay the ?fee
                     odrl:unit ?currency ;
                     ( ids:pipEndpoint ?pipUri ; )?
                 ]
@@ -71,7 +71,7 @@ idsc:RENTAL_REQUEST_TEMPLATE a ids:RentalRequest ;
                 a odrl:Constraint ;
                 odrl:leftOperand idsc:POLICY_EVALUATION_TIME ;
                 odrl:operator idsc:AFTER ;
-                ids:rightOperand ?duration ;                # for a certain usage ?duration
+                odrl:rightOperand ?duration ;                # for a certain usage ?duration
             ]
         ] ;
         ( odrl:constraint idsc:CONSTRAINT_TEMPLATE ; )*      # zero or more Constraints

--- a/examples/contracts-and-usage-policy/templates/RentalTemplates/RENTAL_REQUEST_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/RentalTemplates/RENTAL_REQUEST_TEMPLATE.ttl
@@ -37,7 +37,7 @@ idsc:RENTAL_REQUEST_TEMPLATE a ids:RentalRequest ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
             a odrl:Constraint ;
             odrl:leftOperand idsc:STATE ;
@@ -55,7 +55,7 @@ idsc:RENTAL_REQUEST_TEMPLATE a ids:RentalRequest ;
               (odrl:assigner idsc:PARTICIPANT_TEMPLATE ;         # same value as ids:provider
                odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
             )
-            ids:action [
+            odrl:action [
                 a odrl:Action ;
                 odrl:includedIn idsc:COMPENSATE ;
                 ids:actionRefinement [

--- a/examples/contracts-and-usage-policy/templates/RolebasedAgreementTemplates/ROLEBASED_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/RolebasedAgreementTemplates/ROLEBASED_AGREEMENT_TEMPLATE.jsonld
@@ -12,7 +12,7 @@
         "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:provider,
         "ids:assignee": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:consumer,
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",

--- a/examples/contracts-and-usage-policy/templates/RolebasedAgreementTemplates/ROLEBASED_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/RolebasedAgreementTemplates/ROLEBASED_AGREEMENT_TEMPLATE.jsonld
@@ -16,15 +16,15 @@
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:USER" },
-            "ids:operator": { "@id": "idsc:MEMBER_OF" },
+            "odrl:leftOperand": { "@id": "idsc:USER" },
+            "odrl:operator": { "@id": "idsc:MEMBER_OF" },
             "ids:rightOperandReference": { "@id": "?ParticipantOrganizationUri" }, // the role below is only valid inside the defining organization, so both aspects need to be checked.
             "ids:pipEndpoint": { "@id": "?pipUri"}                // A reference to a Policy Information Point endpoint (might be only locally accessible), which knows about the memberships. For instance the LDAP service.
           },
           {
             "@type:" "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:USER" },
-            "ids:operator": { "@id": "idsc:HAS_MEMBERSHIP" },
+            "odrl:leftOperand": { "@id": "idsc:USER" },
+            "odrl:operator": { "@id": "idsc:HAS_MEMBERSHIP" },
             "ids:rightOperandReference": { "@id": "?RoleURI" },   // the role below is only valid inside the defining organization, so both aspects need to be checked.
             "ids:pipEndpoint": { "@id": "?pipUri"}                // A reference to a Policy Information Point endpoint (might be only locally accessible), which knows about the memberships. For instance the LDAP service.
           }

--- a/examples/contracts-and-usage-policy/templates/RolebasedAgreementTemplates/ROLEBASED_AGREEMENT_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/RolebasedAgreementTemplates/ROLEBASED_AGREEMENT_TEMPLATE.ttl
@@ -25,7 +25,7 @@ idsc:ROLEBASED_AGREEMENT_TEMPLATE a ids:RolebasedAgreement ;
         odrl:assigner idsc:PARTICIPANT_TEMPLATE ;            # same value as ids:provider,
         odrl:assignee idsc:PARTICIPANT_TEMPLATE ;            # same value as ids:consumer,
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
             a odrl:Constraint ;
             odrl:leftOperand idsc:USER ;

--- a/examples/contracts-and-usage-policy/templates/RolebasedAgreementTemplates/ROLEBASED_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/RolebasedAgreementTemplates/ROLEBASED_OFFER_TEMPLATE.jsonld
@@ -28,15 +28,15 @@
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:USER" },
-            "ids:operator": { "@id": "idsc:MEMBER_OF" },
+            "odrl:leftOperand": { "@id": "idsc:USER" },
+            "odrl:operator": { "@id": "idsc:MEMBER_OF" },
             "ids:rightOperandReference": { "@id": "?ParticipantOrganizationUri" }, // the role below is only valid inside the defining organization, so both aspects need to be checked.
             "ids:pipEndpoint": { "@id": "?pipUri"}                // A reference to a Policy Information Point endpoint (might be only locally accessible), which knows about the memberships. For instance the LDAP service.
           },
           {
             "@type:" "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:USER" },
-            "ids:operator": { "@id": "idsc:HAS_MEMBERSHIP" },
+            "odrl:leftOperand": { "@id": "idsc:USER" },
+            "odrl:operator": { "@id": "idsc:HAS_MEMBERSHIP" },
             "ids:rightOperandReference": { "@id": "?RoleURI" },   // the role below is only valid inside the defining organization, so both aspects need to be checked.
             "ids:pipEndpoint": { "@id": "?pipUri"}                // A reference to a Policy Information Point endpoint (might be only locally accessible), which knows about the memberships. For instance the LDAP service.
           }

--- a/examples/contracts-and-usage-policy/templates/RolebasedAgreementTemplates/ROLEBASED_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/RolebasedAgreementTemplates/ROLEBASED_OFFER_TEMPLATE.jsonld
@@ -24,7 +24,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
         )
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",

--- a/examples/contracts-and-usage-policy/templates/RolebasedAgreementTemplates/ROLEBASED_OFFER_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/RolebasedAgreementTemplates/ROLEBASED_OFFER_TEMPLATE.ttl
@@ -37,7 +37,7 @@ idsc:ROLEBASED_RESTRICTED_USAGE_OFFER_TEMPLATE a ids:RolebasedOffer ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
             a odrl:Constraint ;
             odrl:leftOperand idsc:USER ;

--- a/examples/contracts-and-usage-policy/templates/RolebasedAgreementTemplates/ROLEBASED_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/RolebasedAgreementTemplates/ROLEBASED_REQUEST_TEMPLATE.jsonld
@@ -28,15 +28,15 @@
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:USER" },
-            "ids:operator": { "@id": "idsc:MEMBER_OF" },
+            "odrl:leftOperand": { "@id": "idsc:USER" },
+            "odrl:operator": { "@id": "idsc:MEMBER_OF" },
             "ids:rightOperandReference": { "@id": "?ParticipantOrganizationUri" }, // the role below is only valid inside the defining organization, so both aspects need to be checked.
             "ids:pipEndpoint": { "@id": "?pipUri"}                // A reference to a Policy Information Point endpoint (might be only locally accessible), which knows about the memberships. For instance the LDAP service.
           },
           {
             "@type:" "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:USER" },
-            "ids:operator": { "@id": "idsc:HAS_MEMBERSHIP" },
+            "odrl:leftOperand": { "@id": "idsc:USER" },
+            "odrl:operator": { "@id": "idsc:HAS_MEMBERSHIP" },
             "ids:rightOperandReference": { "@id": "?RoleURI" },   // the role below is only valid inside the defining organization, so both aspects need to be checked.
             "ids:pipEndpoint": { "@id": "?pipUri"}                // A reference to a Policy Information Point endpoint (might be only locally accessible), which knows about the memberships. For instance the LDAP service.
           }

--- a/examples/contracts-and-usage-policy/templates/RolebasedAgreementTemplates/ROLEBASED_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/RolebasedAgreementTemplates/ROLEBASED_REQUEST_TEMPLATE.jsonld
@@ -24,7 +24,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
         )
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",

--- a/examples/contracts-and-usage-policy/templates/RolebasedAgreementTemplates/ROLEBASED_REQUEST_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/RolebasedAgreementTemplates/ROLEBASED_REQUEST_TEMPLATE.ttl
@@ -37,7 +37,7 @@ idsc:ROLEBASED_RESTRICTED_USAGE_REQUEST_TEMPLATE a ids:RolebasedRequest ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
             a odrl:Constraint ;
             odrl:leftOperand idsc:USER ;

--- a/examples/contracts-and-usage-policy/templates/SalesTemplates/SALES_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/SalesTemplates/SALES_AGREEMENT_TEMPLATE.jsonld
@@ -24,7 +24,7 @@
                     "@type": "ids:Constraint",
                     "odrl:leftOperand": { "@id": "idsc:PAY_AMOUNT" },
                     "odrl:operator": { "@id": "idsc:EQ" },
-                    "ids:rightOperand": {
+                    "odrl:rightOperand": {
                         "@value": "?price",
                         "@type": "http://www.w3.org/2001/XMLSchema#double"
                     },

--- a/examples/contracts-and-usage-policy/templates/SalesTemplates/SALES_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/SalesTemplates/SALES_AGREEMENT_TEMPLATE.jsonld
@@ -12,13 +12,13 @@
         "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:provider,
         "ids:assignee": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:consumer,
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:preDuty": {
             "@type": "ids:Duty",
             "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),          // same value as ids:provider,
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE),          // same value as ids:consumer,
-            "ids:action": {
-                "@type": "ids:Action",
+            "odrl:action": {
+                "@type": "odrl:Action",
                 "ids:includedIn": { "@id": "idsc:COMPENSATE" },
                 "ids:actionRefinement": {
                     "@type": "ids:Constraint",

--- a/examples/contracts-and-usage-policy/templates/SalesTemplates/SALES_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/SalesTemplates/SALES_AGREEMENT_TEMPLATE.jsonld
@@ -22,8 +22,8 @@
                 "ids:includedIn": { "@id": "idsc:COMPENSATE" },
                 "ids:actionRefinement": {
                     "@type": "ids:Constraint",
-                    "ids:leftOperand": { "@id": "idsc:PAY_AMOUNT" },
-                    "ids:operator": { "@id": "idsc:EQ" },
+                    "odrl:leftOperand": { "@id": "idsc:PAY_AMOUNT" },
+                    "odrl:operator": { "@id": "idsc:EQ" },
                     "ids:rightOperand": {
                         "@value": "?price",
                         "@type": "http://www.w3.org/2001/XMLSchema#double"

--- a/examples/contracts-and-usage-policy/templates/SalesTemplates/SALES_AGREEMENT_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/SalesTemplates/SALES_AGREEMENT_TEMPLATE.ttl
@@ -25,12 +25,12 @@ idsc:SALES_AGREEMENT_TEMPLATE a ids:SalesAgreement ;
         odrl:assigner idsc:PARTICIPANT_TEMPLATE ;            # same value as ids:provider
         odrl:assignee idsc:PARTICIPANT_TEMPLATE ;            # same value as ids:consumer
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         ids:preDuty [
             a odrl:Duty ;
             odrl:assigner idsc:PARTICIPANT_TEMPLATE ;        # same value as ids:provider
             odrl:assignee idsc:PARTICIPANT_TEMPLATE ;        # same value as ids:consumer
-            ids:action [
+            odrl:action [
                 a odrl:Action ;
                 odrl:includedIn idsc:COMPENSATE ;
                 ids:actionRefinement [

--- a/examples/contracts-and-usage-policy/templates/SalesTemplates/SALES_AGREEMENT_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/SalesTemplates/SALES_AGREEMENT_TEMPLATE.ttl
@@ -37,7 +37,7 @@ idsc:SALES_AGREEMENT_TEMPLATE a ids:SalesAgreement ;
                     a odrl:Constraint ;
                     odrl:leftOperand idsc:PAY_AMOUNT ;
                     ids:operator idsc:EQ ;
-                    ids:rightOperand "?price"^^xsd:double ;
+                    odrl:rightOperand "?price"^^xsd:double ;
                     odrl:unit ?currency ;
                 ]
             ] ;

--- a/examples/contracts-and-usage-policy/templates/SalesTemplates/SALES_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/SalesTemplates/SALES_OFFER_TEMPLATE.jsonld
@@ -40,8 +40,8 @@
                 "ids:includedIn": { "@id": "idsc:COMPENSATE" },
                 "ids:actionRefinement": {
                     "@type": "ids:Constraint",
-                    "ids:leftOperand": { "@id": "idsc:PAY_AMOUNT" },
-                    "ids:operator": { "@id": "idsc:EQ" },
+                    "odrl:leftOperand": { "@id": "idsc:PAY_AMOUNT" },
+                    "odrl:operator": { "@id": "idsc:EQ" },
                     "ids:rightOperand": {
                         "@value": "?price",
                         "@type": "http://www.w3.org/2001/XMLSchema#double"

--- a/examples/contracts-and-usage-policy/templates/SalesTemplates/SALES_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/SalesTemplates/SALES_OFFER_TEMPLATE.jsonld
@@ -42,7 +42,7 @@
                     "@type": "ids:Constraint",
                     "odrl:leftOperand": { "@id": "idsc:PAY_AMOUNT" },
                     "odrl:operator": { "@id": "idsc:EQ" },
-                    "ids:rightOperand": {
+                    "odrl:rightOperand": {
                         "@value": "?price",
                         "@type": "http://www.w3.org/2001/XMLSchema#double"
                     },

--- a/examples/contracts-and-usage-policy/templates/SalesTemplates/SALES_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/SalesTemplates/SALES_OFFER_TEMPLATE.jsonld
@@ -24,7 +24,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
         )
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:preDuty": {
             "@type": "ids:Duty",
             (
@@ -35,8 +35,8 @@
               ( "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),           // same value as ids:provider
                 "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
             )
-            "ids:action": {
-                "@type": "ids:Action",
+            "odrl:action": {
+                "@type": "odrl:Action",
                 "ids:includedIn": { "@id": "idsc:COMPENSATE" },
                 "ids:actionRefinement": {
                     "@type": "ids:Constraint",

--- a/examples/contracts-and-usage-policy/templates/SalesTemplates/SALES_OFFER_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/SalesTemplates/SALES_OFFER_TEMPLATE.ttl
@@ -37,7 +37,7 @@ idsc:SALES_OFFER_TEMPLATE a ids:SalesOffer ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         ids:preDuty [
             a odrl:Duty ;
             (
@@ -48,7 +48,7 @@ idsc:SALES_OFFER_TEMPLATE a ids:SalesOffer ;
               (odrl:assigner idsc:PARTICIPANT_TEMPLATE ;         # same value as ids:provider
                odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
             )
-            ids:action [
+            odrl:action [
                 a odrl:Action ;
                 odrl:includedIn idsc:COMPENSATE ;
                 ids:actionRefinement [

--- a/examples/contracts-and-usage-policy/templates/SalesTemplates/SALES_OFFER_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/SalesTemplates/SALES_OFFER_TEMPLATE.ttl
@@ -55,7 +55,7 @@ idsc:SALES_OFFER_TEMPLATE a ids:SalesOffer ;
                     a odrl:Constraint ;
                     odrl:leftOperand idsc:PAY_AMOUNT ;
                     ids:operator idsc:EQ ;
-                    ids:rightOperand "?price"^^xsd:double ;
+                    odrl:rightOperand "?price"^^xsd:double ;
                     odrl:unit ?currency ;
                 ]
             ] ;

--- a/examples/contracts-and-usage-policy/templates/SalesTemplates/SALES_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/SalesTemplates/SALES_REQUEST_TEMPLATE.jsonld
@@ -40,8 +40,8 @@
                 "ids:includedIn": { "@id": "idsc:COMPENSATE" },
                 "ids:actionRefinement": {
                     "@type": "ids:Constraint",
-                    "ids:leftOperand": { "@id": "idsc:PAY_AMOUNT" },
-                    "ids:operator": { "@id": "idsc:EQ" },
+                    "odrl:leftOperand": { "@id": "idsc:PAY_AMOUNT" },
+                    "odrl:operator": { "@id": "idsc:EQ" },
                     "ids:rightOperand": {
                         "@value": "?price",
                         "@type": "http://www.w3.org/2001/XMLSchema#double"

--- a/examples/contracts-and-usage-policy/templates/SalesTemplates/SALES_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/SalesTemplates/SALES_REQUEST_TEMPLATE.jsonld
@@ -42,7 +42,7 @@
                     "@type": "ids:Constraint",
                     "odrl:leftOperand": { "@id": "idsc:PAY_AMOUNT" },
                     "odrl:operator": { "@id": "idsc:EQ" },
-                    "ids:rightOperand": {
+                    "odrl:rightOperand": {
                         "@value": "?price",
                         "@type": "http://www.w3.org/2001/XMLSchema#double"
                     },

--- a/examples/contracts-and-usage-policy/templates/SalesTemplates/SALES_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/SalesTemplates/SALES_REQUEST_TEMPLATE.jsonld
@@ -24,7 +24,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
         )
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:preDuty": {
             "@type": "ids:Duty",
             (
@@ -35,8 +35,8 @@
               ( "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),           // same value as ids:provider
                 "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
             )
-            "ids:action": {
-                "@type": "ids:Action",
+            "odrl:action": {
+                "@type": "odrl:Action",
                 "ids:includedIn": { "@id": "idsc:COMPENSATE" },
                 "ids:actionRefinement": {
                     "@type": "ids:Constraint",

--- a/examples/contracts-and-usage-policy/templates/SalesTemplates/SALES_REQUEST_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/SalesTemplates/SALES_REQUEST_TEMPLATE.ttl
@@ -55,7 +55,7 @@ idsc:SALES_REQUEST_TEMPLATE a ids:SalesRequest ;
                     a odrl:Constraint ;
                     odrl:leftOperand idsc:PAY_AMOUNT ;
                     ids:operator idsc:EQ ;
-                    ids:rightOperand "?price"^^xsd:double ;
+                    odrl:rightOperand "?price"^^xsd:double ;
                     odrl:unit ?currency ;
                 ]
             ] ;

--- a/examples/contracts-and-usage-policy/templates/SalesTemplates/SALES_REQUEST_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/SalesTemplates/SALES_REQUEST_TEMPLATE.ttl
@@ -37,7 +37,7 @@ idsc:SALES_REQUEST_TEMPLATE a ids:SalesRequest ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         ids:preDuty [
             a odrl:Duty ;
             (
@@ -48,7 +48,7 @@ idsc:SALES_REQUEST_TEMPLATE a ids:SalesRequest ;
               (odrl:assigner idsc:PARTICIPANT_TEMPLATE ;         # same value as ids:provider
                odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
             )
-            ids:action [
+            odrl:action [
                 a odrl:Action ;
                 odrl:includedIn idsc:COMPENSATE ;
                 ids:actionRefinement [

--- a/examples/contracts-and-usage-policy/templates/SecurityLevelTemplates/SECURITY_LEVEL_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/SecurityLevelTemplates/SECURITY_LEVEL_AGREEMENT_TEMPLATE.jsonld
@@ -19,20 +19,20 @@
             "ids:or": { "@list": [
                 ({
                   "@type:" "ids:Constraint",
-                  "ids:leftOperand": { "@id": "idsc:SECURITY_LEVEL" },
-                  "ids:operator": { "@id": "idsc:SAME_AS" },
+                  "odrl:leftOperand": { "@id": "idsc:SECURITY_LEVEL" },
+                  "odrl:operator": { "@id": "idsc:SAME_AS" },
                   "ids:rightOperandReference": { "@id": "idsc:BASE_SECURITY_PROFILE" }
                 },)?
                 ({
                   "@type:" "ids:Constraint",
-                  "ids:leftOperand": { "@id": "idsc:SECURITY_LEVEL" },
-                  "ids:operator": { "@id": "idsc:SAME_AS" },
+                  "odrl:leftOperand": { "@id": "idsc:SECURITY_LEVEL" },
+                  "odrl:operator": { "@id": "idsc:SAME_AS" },
                   "ids:rightOperandReference": { "@id": "idsc:TRUST_SECURITY_PROFILE" }     // in case BASE is selected, TRUST must also always be included
                 },)?
                 {
                   "@type:" "ids:Constraint",
-                  "ids:leftOperand": { "@id": "idsc:SECURITY_LEVEL" },
-                  "ids:operator": { "@id": "idsc:SAME_AS" },
+                  "odrl:leftOperand": { "@id": "idsc:SECURITY_LEVEL" },
+                  "odrl:operator": { "@id": "idsc:SAME_AS" },
                   "ids:rightOperandReference": { "@id": "idsc:TRUST_PLUS_SECURITY_PROFILE" } // TRUST+ is always included
                 }
               ]}

--- a/examples/contracts-and-usage-policy/templates/SecurityLevelTemplates/SECURITY_LEVEL_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/SecurityLevelTemplates/SECURITY_LEVEL_AGREEMENT_TEMPLATE.jsonld
@@ -12,7 +12,7 @@
         "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:provider,
         "ids:assignee": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:consumer,
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": [
           {
             "@type:" "ids:LogicalConstraint",

--- a/examples/contracts-and-usage-policy/templates/SecurityLevelTemplates/SECURITY_LEVEL_AGREEMENT_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/SecurityLevelTemplates/SECURITY_LEVEL_AGREEMENT_TEMPLATE.ttl
@@ -24,7 +24,7 @@ idsc:SECURITY_LEVEL_AGREEMENT_TEMPLATE a ids:SecurityAgreement ;
         odrl:assigner idsc:PARTICIPANT_TEMPLATE ;
         odrl:assignee idsc:PARTICIPANT_TEMPLATE ;
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
             a odrl:LogicalConstraint ;
             odrl:or ( # '(' is used as an RDF List operator here

--- a/examples/contracts-and-usage-policy/templates/SecurityLevelTemplates/SECURITY_LEVEL_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/SecurityLevelTemplates/SECURITY_LEVEL_OFFER_TEMPLATE.jsonld
@@ -31,20 +31,20 @@
             "ids:or": { "@list": [
                 ({
                   "@type:" "ids:Constraint",
-                  "ids:leftOperand": { "@id": "idsc:SECURITY_LEVEL" },
-                  "ids:operator": { "@id": "idsc:SAME_AS" },
+                  "odrl:leftOperand": { "@id": "idsc:SECURITY_LEVEL" },
+                  "odrl:operator": { "@id": "idsc:SAME_AS" },
                   "ids:rightOperandReference": { "@id": "idsc:BASE_SECURITY_PROFILE" }
                 },)?
                 ({
                   "@type:" "ids:Constraint",
-                  "ids:leftOperand": { "@id": "idsc:SECURITY_LEVEL" },
-                  "ids:operator": { "@id": "idsc:SAME_AS" },
+                  "odrl:leftOperand": { "@id": "idsc:SECURITY_LEVEL" },
+                  "odrl:operator": { "@id": "idsc:SAME_AS" },
                   "ids:rightOperandReference": { "@id": "idsc:TRUST_SECURITY_PROFILE" }     // in case BASE is selected, TRUST must also always be included
                 },)?
                 {
                   "@type:" "ids:Constraint",
-                  "ids:leftOperand": { "@id": "idsc:SECURITY_LEVEL" },
-                  "ids:operator": { "@id": "idsc:SAME_AS" },
+                  "odrl:leftOperand": { "@id": "idsc:SECURITY_LEVEL" },
+                  "odrl:operator": { "@id": "idsc:SAME_AS" },
                   "ids:rightOperandReference": { "@id": "idsc:TRUST_PLUS_SECURITY_PROFILE" } // TRUST+ is always included
                 }
               ]}

--- a/examples/contracts-and-usage-policy/templates/SecurityLevelTemplates/SECURITY_LEVEL_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/SecurityLevelTemplates/SECURITY_LEVEL_OFFER_TEMPLATE.jsonld
@@ -24,7 +24,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
         )
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": [
           {
             "@type:" "ids:LogicalConstraint",

--- a/examples/contracts-and-usage-policy/templates/SecurityLevelTemplates/SECURITY_LEVEL_OFFER_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/SecurityLevelTemplates/SECURITY_LEVEL_OFFER_TEMPLATE.ttl
@@ -36,7 +36,7 @@ idsc:SECURITY_LEVEL_OFFER_TEMPLATE a ids:SecurityOffer ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
             a odrl:LogicalConstraint ;
             odrl:or ( # '(' is used as an RDF List operator here

--- a/examples/contracts-and-usage-policy/templates/SecurityLevelTemplates/SECURITY_LEVEL_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/SecurityLevelTemplates/SECURITY_LEVEL_REQUEST_TEMPLATE.jsonld
@@ -31,20 +31,20 @@
             "ids:or": { "@list": [
                 ({
                   "@type:" "ids:Constraint",
-                  "ids:leftOperand": { "@id": "idsc:SECURITY_LEVEL" },
-                  "ids:operator": { "@id": "idsc:SAME_AS" },
+                  "odrl:leftOperand": { "@id": "idsc:SECURITY_LEVEL" },
+                  "odrl:operator": { "@id": "idsc:SAME_AS" },
                   "ids:rightOperandReference": { "@id": "idsc:BASE_SECURITY_PROFILE" }
                 },)?
                 ({
                   "@type:" "ids:Constraint",
-                  "ids:leftOperand": { "@id": "idsc:SECURITY_LEVEL" },
-                  "ids:operator": { "@id": "idsc:SAME_AS" },
+                  "odrl:leftOperand": { "@id": "idsc:SECURITY_LEVEL" },
+                  "odrl:operator": { "@id": "idsc:SAME_AS" },
                   "ids:rightOperandReference": { "@id": "idsc:TRUST_SECURITY_PROFILE" }     // in case BASE is selected, TRUST must also always be included
                 },)?
                 {
                   "@type:" "ids:Constraint",
-                  "ids:leftOperand": { "@id": "idsc:SECURITY_LEVEL" },
-                  "ids:operator": { "@id": "idsc:SAME_AS" },
+                  "odrl:leftOperand": { "@id": "idsc:SECURITY_LEVEL" },
+                  "odrl:operator": { "@id": "idsc:SAME_AS" },
                   "ids:rightOperandReference": { "@id": "idsc:TRUST_PLUS_SECURITY_PROFILE" } // TRUST+ is always included
                 }
               ]}

--- a/examples/contracts-and-usage-policy/templates/SecurityLevelTemplates/SECURITY_LEVEL_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/SecurityLevelTemplates/SECURITY_LEVEL_REQUEST_TEMPLATE.jsonld
@@ -24,7 +24,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
         )
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": [
           {
             "@type:" "ids:LogicalConstraint",

--- a/examples/contracts-and-usage-policy/templates/SecurityLevelTemplates/SECURITY_LEVEL_REQUEST_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/SecurityLevelTemplates/SECURITY_LEVEL_REQUEST_TEMPLATE.ttl
@@ -36,7 +36,7 @@ idsc:SECURITY_LEVEL_REQUEST_TEMPLATE a ids:SecurityRequest ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
             a odrl:LogicalConstraint ;
             odrl:or ( # '(' is used as an RDF List operator here

--- a/examples/contracts-and-usage-policy/templates/SpatialRestrictedTemplates/SPATIAL_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/SpatialRestrictedTemplates/SPATIAL_AGREEMENT_TEMPLATE.jsonld
@@ -15,8 +15,8 @@
         "ids:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": {
             "@type": "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:ABSOLUTE_SPATIAL_POSITION" },
-            "ids:operator": { "@id": "?spatialOperator" },
+            "odrl:leftOperand": { "@id": "idsc:ABSOLUTE_SPATIAL_POSITION" },
+            "odrl:operator": { "@id": "?spatialOperator" },
             "ids:rightOperand": {
               (
                   "@id": "?area"                                   // a URI of a named area, for instance http://dbpedia.org/resource/Europe

--- a/examples/contracts-and-usage-policy/templates/SpatialRestrictedTemplates/SPATIAL_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/SpatialRestrictedTemplates/SPATIAL_AGREEMENT_TEMPLATE.jsonld
@@ -12,7 +12,7 @@
         "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:provider,
         "ids:assignee": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:consumer,
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": {
             "@type": "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:ABSOLUTE_SPATIAL_POSITION" },

--- a/examples/contracts-and-usage-policy/templates/SpatialRestrictedTemplates/SPATIAL_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/SpatialRestrictedTemplates/SPATIAL_AGREEMENT_TEMPLATE.jsonld
@@ -17,7 +17,7 @@
             "@type": "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:ABSOLUTE_SPATIAL_POSITION" },
             "odrl:operator": { "@id": "?spatialOperator" },
-            "ids:rightOperand": {
+            "odrl:rightOperand": {
               (
                   "@id": "?area"                                   // a URI of a named area, for instance http://dbpedia.org/resource/Europe
               | // or

--- a/examples/contracts-and-usage-policy/templates/SpatialRestrictedTemplates/SPATIAL_AGREEMENT_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/SpatialRestrictedTemplates/SPATIAL_AGREEMENT_TEMPLATE.ttl
@@ -24,7 +24,7 @@ idsc:SPATIAL_AGREEMENT_TEMPLATE a ids:SpatialAgreement ;
         odrl:assigner idsc:PARTICIPANT_TEMPLATE ;            # same value as ids:provider
         odrl:assignee idsc:PARTICIPANT_TEMPLATE ;            # same value as ids:consumer
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
             a odrl:Constraint ;
             odrl:leftOperand idsc:ABSOLUTE_SPATIAL_POSITION ;

--- a/examples/contracts-and-usage-policy/templates/SpatialRestrictedTemplates/SPATIAL_AGREEMENT_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/SpatialRestrictedTemplates/SPATIAL_AGREEMENT_TEMPLATE.ttl
@@ -29,7 +29,7 @@ idsc:SPATIAL_AGREEMENT_TEMPLATE a ids:SpatialAgreement ;
             a odrl:Constraint ;
             odrl:leftOperand idsc:ABSOLUTE_SPATIAL_POSITION ;
             odrl:operator ?spatialOperator ;                 # the spatial comparison operator, for instance idsc:INSIDE
-            ids:rightOperand (
+            odrl:rightOperand (
               ?area ;                                       # a URI of a named area, for instance http://dbpedia.org/resource/Europe
             | # or
               [

--- a/examples/contracts-and-usage-policy/templates/SpatialRestrictedTemplates/SPATIAL_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/SpatialRestrictedTemplates/SPATIAL_OFFER_TEMPLATE.jsonld
@@ -27,8 +27,8 @@
         "ids:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": {
             "@type": "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:ABSOLUTE_SPATIAL_POSITION" },
-            "ids:operator": { "@id": "?spatialOperator" },
+            "odrl:leftOperand": { "@id": "idsc:ABSOLUTE_SPATIAL_POSITION" },
+            "odrl:operator": { "@id": "?spatialOperator" },
             "ids:rightOperand": {
               (
                   "@id": "?area"                                   // a URI of a named area, for instance http://dbpedia.org/resource/Europe

--- a/examples/contracts-and-usage-policy/templates/SpatialRestrictedTemplates/SPATIAL_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/SpatialRestrictedTemplates/SPATIAL_OFFER_TEMPLATE.jsonld
@@ -24,7 +24,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
         )
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": {
             "@type": "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:ABSOLUTE_SPATIAL_POSITION" },

--- a/examples/contracts-and-usage-policy/templates/SpatialRestrictedTemplates/SPATIAL_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/SpatialRestrictedTemplates/SPATIAL_OFFER_TEMPLATE.jsonld
@@ -29,7 +29,7 @@
             "@type": "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:ABSOLUTE_SPATIAL_POSITION" },
             "odrl:operator": { "@id": "?spatialOperator" },
-            "ids:rightOperand": {
+            "odrl:rightOperand": {
               (
                   "@id": "?area"                                   // a URI of a named area, for instance http://dbpedia.org/resource/Europe
               | // or

--- a/examples/contracts-and-usage-policy/templates/SpatialRestrictedTemplates/SPATIAL_OFFER_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/SpatialRestrictedTemplates/SPATIAL_OFFER_TEMPLATE.ttl
@@ -41,7 +41,7 @@ idsc:SPATIAL_OFFER_TEMPLATE a ids:SpatialOffer ;
             a odrl:Constraint ;
             odrl:leftOperand idsc:ABSOLUTE_SPATIAL_POSITION ;
             odrl:operator ?spatialOperator ;                 # the spatial comparison operator, for instance idsc:INSIDE
-            ids:rightOperand (
+            odrl:rightOperand (
               ?area ;                                       # a URI of a named area, for instance http://dbpedia.org/resource/Europe
             | # or
               [

--- a/examples/contracts-and-usage-policy/templates/SpatialRestrictedTemplates/SPATIAL_OFFER_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/SpatialRestrictedTemplates/SPATIAL_OFFER_TEMPLATE.ttl
@@ -36,7 +36,7 @@ idsc:SPATIAL_OFFER_TEMPLATE a ids:SpatialOffer ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
             a odrl:Constraint ;
             odrl:leftOperand idsc:ABSOLUTE_SPATIAL_POSITION ;

--- a/examples/contracts-and-usage-policy/templates/SpatialRestrictedTemplates/SPATIAL_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/SpatialRestrictedTemplates/SPATIAL_REQUEST_TEMPLATE.jsonld
@@ -27,8 +27,8 @@
         "ids:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": {
             "@type": "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:ABSOLUTE_SPATIAL_POSITION" },
-            "ids:operator": { "@id": "?spatialOperator" },
+            "odrl:leftOperand": { "@id": "idsc:ABSOLUTE_SPATIAL_POSITION" },
+            "odrl:operator": { "@id": "?spatialOperator" },
             "ids:rightOperand": {
               (
                   "@id": "?area"                                   // a URI of a named area, for instance http://dbpedia.org/resource/Europe

--- a/examples/contracts-and-usage-policy/templates/SpatialRestrictedTemplates/SPATIAL_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/SpatialRestrictedTemplates/SPATIAL_REQUEST_TEMPLATE.jsonld
@@ -24,7 +24,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
         )
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": {
             "@type": "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:ABSOLUTE_SPATIAL_POSITION" },

--- a/examples/contracts-and-usage-policy/templates/SpatialRestrictedTemplates/SPATIAL_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/SpatialRestrictedTemplates/SPATIAL_REQUEST_TEMPLATE.jsonld
@@ -29,7 +29,7 @@
             "@type": "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:ABSOLUTE_SPATIAL_POSITION" },
             "odrl:operator": { "@id": "?spatialOperator" },
-            "ids:rightOperand": {
+            "odrl:rightOperand": {
               (
                   "@id": "?area"                                   // a URI of a named area, for instance http://dbpedia.org/resource/Europe
               | // or

--- a/examples/contracts-and-usage-policy/templates/SpatialRestrictedTemplates/SPATIAL_REQUEST_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/SpatialRestrictedTemplates/SPATIAL_REQUEST_TEMPLATE.ttl
@@ -37,7 +37,7 @@ idsc:SPATIAL_REQUEST_TEMPLATE a ids:SpatialRequest ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
             a odrl:Constraint ;
             odrl:leftOperand idsc:ABSOLUTE_SPATIAL_POSITION ;

--- a/examples/contracts-and-usage-policy/templates/SpatialRestrictedTemplates/SPATIAL_REQUEST_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/SpatialRestrictedTemplates/SPATIAL_REQUEST_TEMPLATE.ttl
@@ -42,7 +42,7 @@ idsc:SPATIAL_REQUEST_TEMPLATE a ids:SpatialRequest ;
             a odrl:Constraint ;
             odrl:leftOperand idsc:ABSOLUTE_SPATIAL_POSITION ;
             odrl:operator ?spatialOperator ;                 # the spatial comparison operator, for instance idsc:INSIDE
-            ids:rightOperand (
+            odrl:rightOperand (
               ?area ;                                       # a URI of a named area, for instance http://dbpedia.org/resource/Europe
             | # or
               [

--- a/examples/contracts-and-usage-policy/templates/SwapTemplates/SWAP_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/SwapTemplates/SWAP_AGREEMENT_TEMPLATE.jsonld
@@ -13,7 +13,7 @@
         "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:provider,
         "ids:assignee": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:consumer,
         "ids:target": (idsc:ASSET_TEMPLATE),                      // the Provider's Data Asset
-        "ids:action": (idsc:ACTION_TEMPLATE)
+        "odrl:action": (idsc:ACTION_TEMPLATE)
         (, "ids:constraint": (idsc:CONSTRAINT_TEMPLATE) )*        // zero or more Constraints
         (, "ids:preDuty": (idsc:OBLIGATION_TEMPLATE) )*     // zero or more Obligations which need to be fulfilled before the Usage event
         (, "ids:postDuty": (idsc:OBLIGATION_TEMPLATE) )*    // zero or more Obligations which have to be fulfilled after the Usage event
@@ -22,7 +22,7 @@
         "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:consumer,
         "ids:assignee": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:provider,
         "ids:target": (idsc:ASSET_TEMPLATE),                      // the Consumer's Data Asset
-        "ids:action": (idsc:ACTION_TEMPLATE)
+        "odrl:action": (idsc:ACTION_TEMPLATE)
         (, "ids:constraint": (idsc:CONSTRAINT_TEMPLATE) )*        // zero or more Constraints
         (, "ids:preDuty": (idsc:OBLIGATION_TEMPLATE) )*     // zero or more Obligations which need to be fulfilled before the Usage event
         (, "ids:postDuty": (idsc:OBLIGATION_TEMPLATE) )*    // zero or more Obligations which have to be fulfilled after the Usage event

--- a/examples/contracts-and-usage-policy/templates/SwapTemplates/SWAP_AGREEMENT_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/SwapTemplates/SWAP_AGREEMENT_TEMPLATE.ttl
@@ -25,7 +25,7 @@ idsc:SWAP_AGREEMENT_TEMPLATE a ids:SwapAgreement ;
         odrl:assigner idsc:PARTICIPANT_TEMPLATE ;            # same value as ids:provider
         odrl:assignee idsc:PARTICIPANT_TEMPLATE ;            # same value as ids:consumer
         ids:target idsc:ASSET_TEMPLATE ;                    # the Provider's Data Asset
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         ( odrl:constraint idsc:CONSTRAINT_TEMPLATE ; )*      # zero or more Constraints
         ( ids:preDuty idsc:OBLIGATION_TEMPLATE ; )*   # zero or more Obligations which need to be fulfilled before the Usage event
         ( ids:postDuty idsc:OBLIGATION_TEMPLATE ; )*  # zero or more Obligations which have to be fulfilled after the Usage event
@@ -35,7 +35,7 @@ idsc:SWAP_AGREEMENT_TEMPLATE a ids:SwapAgreement ;
         odrl:assigner idsc:PARTICIPANT_TEMPLATE ;            # same value as ids:consumer
         odrl:assignee idsc:PARTICIPANT_TEMPLATE ;            # same value as ids:provider
         ids:target idsc:ASSET_TEMPLATE ;                    # the Consumer's Data Asset
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         ( odrl:constraint idsc:CONSTRAINT_TEMPLATE ; )*      # zero or more Constraints
         ( ids:preDuty idsc:OBLIGATION_TEMPLATE ; )*   # zero or more Obligations which need to be fulfilled before the Usage event
         ( ids:postDuty idsc:OBLIGATION_TEMPLATE ; )*  # zero or more Obligations which have to be fulfilled after the Usage event

--- a/examples/contracts-and-usage-policy/templates/SwapTemplates/SWAP_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/SwapTemplates/SWAP_OFFER_TEMPLATE.jsonld
@@ -25,7 +25,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )        // same value as ids:consumer
         )
         "ids:target": (idsc:ASSET_TEMPLATE),                      // the Provider's Data Asset
-        "ids:action": (idsc:ACTION_TEMPLATE)
+        "odrl:action": (idsc:ACTION_TEMPLATE)
         (, "ids:constraint": (idsc:CONSTRAINT_TEMPLATE) )*        // zero or more Constraints
         (, "ids:preDuty": (idsc:OBLIGATION_TEMPLATE) )*     // zero or more Obligations which need to be fulfilled before the Usage event
         (, "ids:postDuty": (idsc:OBLIGATION_TEMPLATE) )*    // zero or more Obligations which have to be fulfilled after the Usage event
@@ -40,7 +40,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )        // same value as ids:provider
         )
         "ids:target": (idsc:ASSET_TEMPLATE),                      // the Consumer's Data Asset
-        "ids:action": (idsc:ACTION_TEMPLATE)
+        "odrl:action": (idsc:ACTION_TEMPLATE)
         (, "ids:constraint": (idsc:CONSTRAINT_TEMPLATE) )*        // zero or more Constraints
         (, "ids:preDuty": (idsc:OBLIGATION_TEMPLATE) )*     // zero or more Obligations which need to be fulfilled before the Usage event
         (, "ids:postDuty": (idsc:OBLIGATION_TEMPLATE) )*    // zero or more Obligations which have to be fulfilled after the Usage event

--- a/examples/contracts-and-usage-policy/templates/SwapTemplates/SWAP_OFFER_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/SwapTemplates/SWAP_OFFER_TEMPLATE.ttl
@@ -37,7 +37,7 @@ idsc:SWAP_OFFER_TEMPLATE a ids:SwapOffer ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;                   # the Provider's Data Asset
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         ( odrl:constraint idsc:CONSTRAINT_TEMPLATE ; )*      # zero or more Constraints
         ( ids:preDuty idsc:OBLIGATION_TEMPLATE ; )*   # zero or more additional Obligations which need to be fulfilled before the Usage event
         ( ids:postDuty idsc:OBLIGATION_TEMPLATE ; )*  # zero or more Obligations which have to be fulfilled after the Usage event
@@ -53,7 +53,7 @@ idsc:SWAP_OFFER_TEMPLATE a ids:SwapOffer ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:provider
         )
         ids:target idsc:ASSET_TEMPLATE ;                   # the Consumer's Data Asset
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         ( odrl:constraint idsc:CONSTRAINT_TEMPLATE ; )*      # zero or more Constraints
         ( ids:preDuty idsc:OBLIGATION_TEMPLATE ; )*   # zero or more additional Obligations which need to be fulfilled before the Usage event
         ( ids:postDuty idsc:OBLIGATION_TEMPLATE ; )*  # zero or more Obligations which have to be fulfilled after the Usage event

--- a/examples/contracts-and-usage-policy/templates/SwapTemplates/SWAP_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/SwapTemplates/SWAP_REQUEST_TEMPLATE.jsonld
@@ -25,7 +25,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )        // same value as ids:consumer
         )
         "ids:target": (idsc:ASSET_TEMPLATE),                      // the Provider's Data Asset
-        "ids:action": (idsc:ACTION_TEMPLATE)
+        "odrl:action": (idsc:ACTION_TEMPLATE)
         (, "ids:constraint": (idsc:CONSTRAINT_TEMPLATE) )*        // zero or more Constraints
         (, "ids:preDuty": (idsc:OBLIGATION_TEMPLATE) )*     // zero or more Obligations which need to be fulfilled before the Usage event
         (, "ids:postDuty": (idsc:OBLIGATION_TEMPLATE) )*    // zero or more Obligations which have to be fulfilled after the Usage event
@@ -40,7 +40,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )        // same value as ids:provider
         )
         "ids:target": (idsc:ASSET_TEMPLATE),                      // the Consumer's Data Asset
-        "ids:action": (idsc:ACTION_TEMPLATE)
+        "odrl:action": (idsc:ACTION_TEMPLATE)
         (, "ids:constraint": (idsc:CONSTRAINT_TEMPLATE) )*        // zero or more Constraints
         (, "ids:preDuty": (idsc:OBLIGATION_TEMPLATE) )*     // zero or more Obligations which need to be fulfilled before the Usage event
         (, "ids:postDuty": (idsc:OBLIGATION_TEMPLATE) )*    // zero or more Obligations which have to be fulfilled after the Usage event

--- a/examples/contracts-and-usage-policy/templates/SwapTemplates/SWAP_REQUEST_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/SwapTemplates/SWAP_REQUEST_TEMPLATE.ttl
@@ -37,7 +37,7 @@ idsc:SWAP_REQUEST_TEMPLATE a ids:SwapRequest ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;                   # the Provider's Data Asset
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         ( odrl:constraint idsc:CONSTRAINT_TEMPLATE ; )*      # zero or more Constraints
         ( ids:preDuty idsc:OBLIGATION_TEMPLATE ; )*   # zero or more Obligations which need to be fulfilled before the Usage event
         ( ids:postDuty idsc:OBLIGATION_TEMPLATE ; )*  # zero or more Obligations which have to be fulfilled after the Usage event
@@ -53,7 +53,7 @@ idsc:SWAP_REQUEST_TEMPLATE a ids:SwapRequest ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:provider
         )
         ids:target idsc:ASSET_TEMPLATE ;                   # the Consumer's Data Asset
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         ( odrl:constraint idsc:CONSTRAINT_TEMPLATE ; )*      # zero or more Constraints
         ( ids:preDuty idsc:OBLIGATION_TEMPLATE ; )*   # zero or more Obligations which need to be fulfilled before the Usage event
         ( ids:postDuty idsc:OBLIGATION_TEMPLATE ; )*  # zero or more Obligations which have to be fulfilled after the Usage event

--- a/examples/contracts-and-usage-policy/templates/TargetTemplates/ASSET_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TargetTemplates/ASSET_TEMPLATE.jsonld
@@ -18,7 +18,7 @@
         "@type": "ids:Constraint",                              // Define a collection of data objects which, for instance, all have an explicit attribute "color":"blue"
         "odrl:leftOperand": { "@id": "?IdscLeftOperand" },       // The feature of interest, for instance ?IdscLeftOperand := idsc:PATH
         "odrl:operator": { "@id": "?IdscBinaryOperator" },       // The kind of check, which shall be executed on the feature of interest, for instance ?IdscBinaryOperator := idsc:STRING_EQ
-        "ids:rightOperand": { "@id": "?Value" }                 // The value expression all members of this collection have to share, for instance ?Value := "blue"
+        "odrl:rightOperand": { "@id": "?Value" }                 // The value expression all members of this collection have to share, for instance ?Value := "blue"
         (, "ids:pipEndpoint": { "@id": "?AttributeLocation"} )? // A URI or path expression to the target attribute, ?AttributeLocation := "//color"
         (, "ids:unit": { "@id": "?Unit" } )?                    // A unit which may further explain the ?Value, for instance <http://dbpedia.org/resource/Color>.
       }
@@ -37,7 +37,7 @@
                 "@type": "ids:Constraint",
                 "odrl:leftOperand": { "@id": "?IdscLeftOperand" },
                 "odrl:operator": { "@id": "?IdsBinaryOperator" },
-                "ids:rightOperand": { "@id": "?Value" }
+                "odrl:rightOperand": { "@id": "?Value" }
                 (, "ids:pipEndpoint": { "@id": "?AttributeLocation" } )?
                 (, "ids:unit": { "@id": "?Unit" } )?
               }

--- a/examples/contracts-and-usage-policy/templates/TargetTemplates/ASSET_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TargetTemplates/ASSET_TEMPLATE.jsonld
@@ -16,8 +16,8 @@
     "ids:assetRefinement": [
       {
         "@type": "ids:Constraint",                              // Define a collection of data objects which, for instance, all have an explicit attribute "color":"blue"
-        "ids:leftOperand": { "@id": "?IdscLeftOperand" },       // The feature of interest, for instance ?IdscLeftOperand := idsc:PATH
-        "ids:operator": { "@id": "?IdscBinaryOperator" },       // The kind of check, which shall be executed on the feature of interest, for instance ?IdscBinaryOperator := idsc:STRING_EQ
+        "odrl:leftOperand": { "@id": "?IdscLeftOperand" },       // The feature of interest, for instance ?IdscLeftOperand := idsc:PATH
+        "odrl:operator": { "@id": "?IdscBinaryOperator" },       // The kind of check, which shall be executed on the feature of interest, for instance ?IdscBinaryOperator := idsc:STRING_EQ
         "ids:rightOperand": { "@id": "?Value" }                 // The value expression all members of this collection have to share, for instance ?Value := "blue"
         (, "ids:pipEndpoint": { "@id": "?AttributeLocation"} )? // A URI or path expression to the target attribute, ?AttributeLocation := "//color"
         (, "ids:unit": { "@id": "?Unit" } )?                    // A unit which may further explain the ?Value, for instance <http://dbpedia.org/resource/Color>.
@@ -35,8 +35,8 @@
             (
               {
                 "@type": "ids:Constraint",
-                "ids:leftOperand": { "@id": "?IdscLeftOperand" },
-                "ids:operator": { "@id": "?IdsBinaryOperator" },
+                "odrl:leftOperand": { "@id": "?IdscLeftOperand" },
+                "odrl:operator": { "@id": "?IdsBinaryOperator" },
                 "ids:rightOperand": { "@id": "?Value" }
                 (, "ids:pipEndpoint": { "@id": "?AttributeLocation" } )?
                 (, "ids:unit": { "@id": "?Unit" } )?

--- a/examples/contracts-and-usage-policy/templates/TargetTemplates/ASSET_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/TargetTemplates/ASSET_TEMPLATE.ttl
@@ -28,7 +28,7 @@
             a odrl:Constraint ;                              # Define a collection of data objects which, for instance, all have an explicit attribute "color":"blue"
             odrl:leftOperand ?IdscLeftOperand ;              # The feature of interest, for instance ?IdscLeftOperand := idsc:PATH
             odrl:operator ?IdscBinaryOperator ;              # The kind of check, which shall be executed on the feature of interest, for instance ?IdscBinaryOperator := idsc:STRING_EQ
-            ids:rightOperand ?Value ;                       # The value expression all members of this collection have to share, for instance ?Value := "blue"
+            odrl:rightOperand ?Value ;                       # The value expression all members of this collection have to share, for instance ?Value := "blue"
             ( ids:pipEndpoint ?AttributeLocation ; )?       # A URI or path expression to the target attribute, ?AttributeLocation := "//color"
             ( odrl:unit ?Unit ; )?                           # A unit which may further explain the ?Value, for instance <http://dbpedia.org/resource/Color>.
         ]
@@ -44,7 +44,7 @@
                         a odrl:Constraint ;
                         odrl:leftOperand ?IdscLeftOperand ;
                         odrl:operator ?IdsBinaryOperator ;
-                        ids:rightOperand ?Value ;
+                        odrl:rightOperand ?Value ;
                         ( ids:pipEndpoint ?AttributeLocation ; )?
                         ( odrl:unit ?Unit ; )?
                     ){2,} # at least two constraints

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_AGREEMENT_TEMPLATE.jsonld
@@ -15,8 +15,8 @@
         "ids:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": {
             "@type": "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:ELAPSED_TIME" },
-            "ids:operator": { "@id": "idsc:SHORTER_EQ" },
+            "odrl:leftOperand": { "@id": "idsc:ELAPSED_TIME" },
+            "odrl:operator": { "@id": "idsc:SHORTER_EQ" },
             "ids:rightOperand": {
                 "@value": "?duration",                            // for a certain usage ?duration
                 "@type": "http://www.w3.org/2001/XMLSchema#duration"

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_AGREEMENT_TEMPLATE.jsonld
@@ -17,7 +17,7 @@
             "@type": "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:ELAPSED_TIME" },
             "odrl:operator": { "@id": "idsc:SHORTER_EQ" },
-            "ids:rightOperand": {
+            "odrl:rightOperand": {
                 "@value": "?duration",                            // for a certain usage ?duration
                 "@type": "http://www.w3.org/2001/XMLSchema#duration"
             }

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_AGREEMENT_TEMPLATE.jsonld
@@ -12,7 +12,7 @@
         "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:provider,
         "ids:assignee": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:consumer,
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": {
             "@type": "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:ELAPSED_TIME" },

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_AGREEMENT_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_AGREEMENT_TEMPLATE.ttl
@@ -24,7 +24,7 @@ idsc:DURATION_AGREEMENT_TEMPLATE a ids:DurationAgreement ;
         odrl:assigner idsc:PARTICIPANT_TEMPLATE ;            # same value as ids:provider
         odrl:assignee idsc:PARTICIPANT_TEMPLATE ;            # same value as ids:consumer
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
             a odrl:Constraint ;
             odrl:leftOperand idsc:ELAPSED_TIME ;

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_AGREEMENT_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_AGREEMENT_TEMPLATE.ttl
@@ -29,7 +29,7 @@ idsc:DURATION_AGREEMENT_TEMPLATE a ids:DurationAgreement ;
             a odrl:Constraint ;
             odrl:leftOperand idsc:ELAPSED_TIME ;
             ids:operator idsc:SHORTER_EQ ;
-            ids:rightOperand ?duration ;                    # for a certain usage ?duration
+            odrl:rightOperand ?duration ;                    # for a certain usage ?duration
         ] ;
         ( odrl:constraint idsc:CONSTRAINT_TEMPLATE ; )*      # zero or more Constraints
         ( ids:preDuty idsc:OBLIGATION_TEMPLATE ; )*   # zero or more Obligations which need to be fulfilled before the Usage event

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_OFFER_TEMPLATE.jsonld
@@ -24,7 +24,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
         )
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": {
             "@type": "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:ELAPSED_TIME" },

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_OFFER_TEMPLATE.jsonld
@@ -27,8 +27,8 @@
         "ids:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": {
             "@type": "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:ELAPSED_TIME" },
-            "ids:operator": { "@id": "idsc:SHORTER_EQ" },
+            "odrl:leftOperand": { "@id": "idsc:ELAPSED_TIME" },
+            "odrl:operator": { "@id": "idsc:SHORTER_EQ" },
             "ids:rightOperand": {
                 "@value": "?duration",                   // for a certain usage ?duration
                 "@type": "http://www.w3.org/2001/XMLSchema#duration"

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_OFFER_TEMPLATE.jsonld
@@ -29,7 +29,7 @@
             "@type": "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:ELAPSED_TIME" },
             "odrl:operator": { "@id": "idsc:SHORTER_EQ" },
-            "ids:rightOperand": {
+            "odrl:rightOperand": {
                 "@value": "?duration",                   // for a certain usage ?duration
                 "@type": "http://www.w3.org/2001/XMLSchema#duration"
             }

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_OFFER_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_OFFER_TEMPLATE.ttl
@@ -37,7 +37,7 @@ idsc:DURATION_OFFER_TEMPLATE a ids:DurationOffer ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
             a odrl:Constraint ;
             odrl:leftOperand idsc:ELAPSED_TIME ;

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_OFFER_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_OFFER_TEMPLATE.ttl
@@ -42,7 +42,7 @@ idsc:DURATION_OFFER_TEMPLATE a ids:DurationOffer ;
             a odrl:Constraint ;
             odrl:leftOperand idsc:ELAPSED_TIME ;
             ids:operator idsc:SHORTER_EQ ;
-            ids:rightOperand ?duration ;                    # for a certain usage ?duration
+            odrl:rightOperand ?duration ;                    # for a certain usage ?duration
         ] ;
         ( odrl:constraint idsc:CONSTRAINT_TEMPLATE ; )*      # zero or more Constraints
         ( ids:preDuty idsc:OBLIGATION_TEMPLATE ; )*   # zero or more Obligations which need to be fulfilled before the Usage event

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_REQUEST_TEMPLATE.jsonld
@@ -24,7 +24,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
         )
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": {
             "@type": "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:ELAPSED_TIME" },

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_REQUEST_TEMPLATE.jsonld
@@ -27,8 +27,8 @@
         "ids:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": {
             "@type": "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:ELAPSED_TIME" },
-            "ids:operator": { "@id": "idsc:DURATION_EQ" },
+            "odrl:leftOperand": { "@id": "idsc:ELAPSED_TIME" },
+            "odrl:operator": { "@id": "idsc:DURATION_EQ" },
             "ids:rightOperand": {
                 "@value": "?duration",                            // for a certain usage ?duration
                 "@type": "http://www.w3.org/2001/XMLSchema#duration"

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_REQUEST_TEMPLATE.jsonld
@@ -29,7 +29,7 @@
             "@type": "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:ELAPSED_TIME" },
             "odrl:operator": { "@id": "idsc:DURATION_EQ" },
-            "ids:rightOperand": {
+            "odrl:rightOperand": {
                 "@value": "?duration",                            // for a certain usage ?duration
                 "@type": "http://www.w3.org/2001/XMLSchema#duration"
             }

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_REQUEST_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_REQUEST_TEMPLATE.ttl
@@ -37,7 +37,7 @@ idsc:DURATION_REQUEST_TEMPLATE a ids:DurationRequest ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
             a odrl:Constraint ;
             odrl:leftOperand idsc:ELAPSED_TIME ;

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_REQUEST_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_REQUEST_TEMPLATE.ttl
@@ -42,7 +42,7 @@ idsc:DURATION_REQUEST_TEMPLATE a ids:DurationRequest ;
             a odrl:Constraint ;
             odrl:leftOperand idsc:ELAPSED_TIME ;
             ids:operator idsc:SHORTER_EQ ;
-            ids:rightOperand ?duration ;                    # for a certain usage ?duration
+            odrl:rightOperand ?duration ;                    # for a certain usage ?duration
         ] ;
         ( odrl:constraint idsc:CONSTRAINT_TEMPLATE ; )*      # zero or more Constraints
         ( ids:preDuty idsc:OBLIGATION_TEMPLATE ; )*   # zero or more Obligations which need to be fulfilled before the Usage event

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_USAGE_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_USAGE_AGREEMENT_TEMPLATE.jsonld
@@ -15,8 +15,8 @@
         "ids:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": {
             "@type": "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:ELAPSED_TIME" },
-            "ids:operator": { "@id": "idsc:SHORTER_EQ" },
+            "odrl:leftOperand": { "@id": "idsc:ELAPSED_TIME" },
+            "odrl:operator": { "@id": "idsc:SHORTER_EQ" },
             "ids:rightOperand": {
                 "@value": "?duration",                            // for a certain usage ?duration
                 "@type": "http://www.w3.org/2001/XMLSchema#duration"

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_USAGE_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_USAGE_AGREEMENT_TEMPLATE.jsonld
@@ -17,7 +17,7 @@
             "@type": "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:ELAPSED_TIME" },
             "odrl:operator": { "@id": "idsc:SHORTER_EQ" },
-            "ids:rightOperand": {
+            "odrl:rightOperand": {
                 "@value": "?duration",                            // for a certain usage ?duration
                 "@type": "http://www.w3.org/2001/XMLSchema#duration"
             }

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_USAGE_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_USAGE_AGREEMENT_TEMPLATE.jsonld
@@ -12,7 +12,7 @@
         "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:provider,
         "ids:assignee": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:consumer,
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": {
             "@type": "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:ELAPSED_TIME" },

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_USAGE_AGREEMENT_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_USAGE_AGREEMENT_TEMPLATE.ttl
@@ -24,7 +24,7 @@ idsc:DURATION_AGREEMENT_TEMPLATE a ids:DurationAgreement ;
         odrl:assigner idsc:PARTICIPANT_TEMPLATE ;            # same value as ids:provider
         odrl:assignee idsc:PARTICIPANT_TEMPLATE ;            # same value as ids:consumer
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
             a odrl:Constraint ;
             odrl:leftOperand idsc:ELAPSED_TIME ;

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_USAGE_AGREEMENT_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_USAGE_AGREEMENT_TEMPLATE.ttl
@@ -29,7 +29,7 @@ idsc:DURATION_AGREEMENT_TEMPLATE a ids:DurationAgreement ;
             a odrl:Constraint ;
             odrl:leftOperand idsc:ELAPSED_TIME ;
             ids:operator idsc:SHORTER_EQ ;
-            ids:rightOperand ?duration ;                    # for a certain usage ?duration
+            odrl:rightOperand ?duration ;                    # for a certain usage ?duration
         ] ;
         ( odrl:constraint idsc:CONSTRAINT_TEMPLATE ; )*      # zero or more Constraints
         ( ids:preDuty idsc:OBLIGATION_TEMPLATE ; )*   # zero or more Obligations which need to be fulfilled before the Usage event

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_USAGE_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_USAGE_OFFER_TEMPLATE.jsonld
@@ -24,7 +24,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
         )
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": {
             "@type": "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:ELAPSED_TIME" },

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_USAGE_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_USAGE_OFFER_TEMPLATE.jsonld
@@ -27,8 +27,8 @@
         "ids:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": {
             "@type": "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:ELAPSED_TIME" },
-            "ids:operator": { "@id": "idsc:SHORTER_EQ" },
+            "odrl:leftOperand": { "@id": "idsc:ELAPSED_TIME" },
+            "odrl:operator": { "@id": "idsc:SHORTER_EQ" },
             "ids:rightOperand": {
                 "@value": "?duration",                   // for a certain usage ?duration
                 "@type": "http://www.w3.org/2001/XMLSchema#duration"

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_USAGE_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_USAGE_OFFER_TEMPLATE.jsonld
@@ -29,7 +29,7 @@
             "@type": "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:ELAPSED_TIME" },
             "odrl:operator": { "@id": "idsc:SHORTER_EQ" },
-            "ids:rightOperand": {
+            "odrl:rightOperand": {
                 "@value": "?duration",                   // for a certain usage ?duration
                 "@type": "http://www.w3.org/2001/XMLSchema#duration"
             }

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_USAGE_OFFER_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_USAGE_OFFER_TEMPLATE.ttl
@@ -37,7 +37,7 @@ idsc:DURATION_OFFER_TEMPLATE a ids:DurationOffer ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
             a odrl:Constraint ;
             odrl:leftOperand idsc:ELAPSED_TIME ;

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_USAGE_OFFER_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_USAGE_OFFER_TEMPLATE.ttl
@@ -42,7 +42,7 @@ idsc:DURATION_OFFER_TEMPLATE a ids:DurationOffer ;
             a odrl:Constraint ;
             odrl:leftOperand idsc:ELAPSED_TIME ;
             ids:operator idsc:SHORTER_EQ ;
-            ids:rightOperand ?duration ;                    # for a certain usage ?duration
+            odrl:rightOperand ?duration ;                    # for a certain usage ?duration
         ] ;
         ( odrl:constraint idsc:CONSTRAINT_TEMPLATE ; )*      # zero or more Constraints
         ( ids:preDuty idsc:OBLIGATION_TEMPLATE ; )*   # zero or more Obligations which need to be fulfilled before the Usage event

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_USAGE_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_USAGE_REQUEST_TEMPLATE.jsonld
@@ -24,7 +24,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
         )
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": {
             "@type": "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:ELAPSED_TIME" },

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_USAGE_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_USAGE_REQUEST_TEMPLATE.jsonld
@@ -27,8 +27,8 @@
         "ids:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": {
             "@type": "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:ELAPSED_TIME" },
-            "ids:operator": { "@id": "idsc:DURATION_EQ" },
+            "odrl:leftOperand": { "@id": "idsc:ELAPSED_TIME" },
+            "odrl:operator": { "@id": "idsc:DURATION_EQ" },
             "ids:rightOperand": {
                 "@value": "?duration",                            // for a certain usage ?duration
                 "@type": "http://www.w3.org/2001/XMLSchema#duration"

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_USAGE_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_USAGE_REQUEST_TEMPLATE.jsonld
@@ -29,7 +29,7 @@
             "@type": "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:ELAPSED_TIME" },
             "odrl:operator": { "@id": "idsc:DURATION_EQ" },
-            "ids:rightOperand": {
+            "odrl:rightOperand": {
                 "@value": "?duration",                            // for a certain usage ?duration
                 "@type": "http://www.w3.org/2001/XMLSchema#duration"
             }

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_USAGE_REQUEST_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_USAGE_REQUEST_TEMPLATE.ttl
@@ -37,7 +37,7 @@ idsc:DURATION_REQUEST_TEMPLATE a ids:DurationRequest ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
             a odrl:Constraint ;
             odrl:leftOperand idsc:ELAPSED_TIME ;

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_USAGE_REQUEST_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/DURATION_USAGE_REQUEST_TEMPLATE.ttl
@@ -42,7 +42,7 @@ idsc:DURATION_REQUEST_TEMPLATE a ids:DurationRequest ;
             a odrl:Constraint ;
             odrl:leftOperand idsc:ELAPSED_TIME ;
             ids:operator idsc:SHORTER_EQ ;
-            ids:rightOperand ?duration ;                    # for a certain usage ?duration
+            odrl:rightOperand ?duration ;                    # for a certain usage ?duration
         ] ;
         ( odrl:constraint idsc:CONSTRAINT_TEMPLATE ; )*      # zero or more Constraints
         ( ids:preDuty idsc:OBLIGATION_TEMPLATE ; )*   # zero or more Obligations which need to be fulfilled before the Usage event

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_DURING_INTERVAL_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_DURING_INTERVAL_AGREEMENT_TEMPLATE.jsonld
@@ -12,7 +12,7 @@
         "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:provider,
         "ids:assignee": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:consumer,
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": [{
             "@type": "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_DURING_INTERVAL_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_DURING_INTERVAL_AGREEMENT_TEMPLATE.jsonld
@@ -17,7 +17,7 @@
             "@type": "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
             "odrl:operator": { "@id": "idsc:AFTER" },
-            "ids:rightOperand": {
+            "odrl:rightOperand": {
                 "@value": "?startDateTime",                   // ?startDateTime < ?endDateTime
                 "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
             }
@@ -25,7 +25,7 @@
             "@type": "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
             "odrl:operator": { "@id": "idsc:BEFORE" },
-            "ids:rightOperand": {
+            "odrl:rightOperand": {
                 "@value": "?endDateTime",
                 "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
             }

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_DURING_INTERVAL_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_DURING_INTERVAL_AGREEMENT_TEMPLATE.jsonld
@@ -15,16 +15,16 @@
         "ids:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": [{
             "@type": "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
-            "ids:operator": { "@id": "idsc:AFTER" },
+            "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
+            "odrl:operator": { "@id": "idsc:AFTER" },
             "ids:rightOperand": {
                 "@value": "?startDateTime",                   // ?startDateTime < ?endDateTime
                 "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
             }
 		},{
             "@type": "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
-            "ids:operator": { "@id": "idsc:BEFORE" },
+            "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
+            "odrl:operator": { "@id": "idsc:BEFORE" },
             "ids:rightOperand": {
                 "@value": "?endDateTime",
                 "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_DURING_INTERVAL_AGREEMENT_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_DURING_INTERVAL_AGREEMENT_TEMPLATE.ttl
@@ -25,7 +25,7 @@ idsc:USAGE_DURING_INTERVAL_AGREEMENT_TEMPLATE a ids:IntervalUsageAgreement ;
         odrl:assigner idsc:PARTICIPANT_TEMPLATE ;            # same value as ids:provider
         odrl:assignee idsc:PARTICIPANT_TEMPLATE ;            # same value as ids:consumer
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
 					odrl:leftOperand idsc:POLICY_EVALUATION_TIME ;
 					ids:operator idsc:AFTER ;

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_DURING_INTERVAL_AGREEMENT_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_DURING_INTERVAL_AGREEMENT_TEMPLATE.ttl
@@ -29,12 +29,12 @@ idsc:USAGE_DURING_INTERVAL_AGREEMENT_TEMPLATE a ids:IntervalUsageAgreement ;
         odrl:constraint [
 					odrl:leftOperand idsc:POLICY_EVALUATION_TIME ;
 					ids:operator idsc:AFTER ;
-					ids:rightOperand "?startDateTime"^^xsd:dateTimeStamp ; # ?startDateTime < ?endDateTime
+					odrl:rightOperand "?startDateTime"^^xsd:dateTimeStamp ; # ?startDateTime < ?endDateTime
 				] ;
 				odrl:constraint [
 					odrl:leftOperand ids:POLICY_EVALUATION_TIME ;
 					ids:operator idsc:BEFORE ;
-					ids:rightOperand "?endDateTime"^^xsd:dateTimeStamp ;
+					odrl:rightOperand "?endDateTime"^^xsd:dateTimeStamp ;
 				] ;
         ( odrl:constraint idsc:CONSTRAINT_TEMPLATE ; )*      # zero or more Constraints
         ( ids:preDuty idsc:OBLIGATION_TEMPLATE ; )*   # zero or more Obligations which need to be fulfilled before the Usage event

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_DURING_INTERVAL_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_DURING_INTERVAL_OFFER_TEMPLATE.jsonld
@@ -30,7 +30,7 @@
             "@type:" "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
             "odrl:operator": { "@id": "idsc:AFTER" },
-            "ids:rightOperand": {
+            "odrl:rightOperand": {
                 "@value": "?startDateTime",                   // ?startDateTime < ?endDateTime
                 "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
             }
@@ -40,7 +40,7 @@
             "@type:" "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
             "odrl:operator": { "@id": "idsc:BEFORE" },
-            "ids:rightOperand": {
+            "odrl:rightOperand": {
                 "@value": "?endDateTime",
                 "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
             }

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_DURING_INTERVAL_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_DURING_INTERVAL_OFFER_TEMPLATE.jsonld
@@ -28,8 +28,8 @@
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
-            "ids:operator": { "@id": "idsc:AFTER" },
+            "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
+            "odrl:operator": { "@id": "idsc:AFTER" },
             "ids:rightOperand": {
                 "@value": "?startDateTime",                   // ?startDateTime < ?endDateTime
                 "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
@@ -38,8 +38,8 @@
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
-            "ids:operator": { "@id": "idsc:BEFORE" },
+            "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
+            "odrl:operator": { "@id": "idsc:BEFORE" },
             "ids:rightOperand": {
                 "@value": "?endDateTime",
                 "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_DURING_INTERVAL_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_DURING_INTERVAL_OFFER_TEMPLATE.jsonld
@@ -24,7 +24,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
         )
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_DURING_INTERVAL_OFFER_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_DURING_INTERVAL_OFFER_TEMPLATE.ttl
@@ -37,7 +37,7 @@ idsc:USAGE_DURING_INTERVAL_OFFER_TEMPLATE a ids:IntervalUsageOffer ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
 					odrl:leftOperand idsc:POLICY_EVALUATION_TIME ;
 					ids:operator idsc:AFTER ;

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_DURING_INTERVAL_OFFER_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_DURING_INTERVAL_OFFER_TEMPLATE.ttl
@@ -41,12 +41,12 @@ idsc:USAGE_DURING_INTERVAL_OFFER_TEMPLATE a ids:IntervalUsageOffer ;
         odrl:constraint [
 					odrl:leftOperand idsc:POLICY_EVALUATION_TIME ;
 					ids:operator idsc:AFTER ;
-					ids:rightOperand "?startDateTime"^^xsd:dateTimeStamp ; # ?startDateTime < ?endDateTime
+					odrl:rightOperand "?startDateTime"^^xsd:dateTimeStamp ; # ?startDateTime < ?endDateTime
 				] ;
 				odrl:constraint [
 					odrl:leftOperand ids:POLICY_EVALUATION_TIME ;
 					ids:operator idsc:BEFORE ;
-					ids:rightOperand "?endDateTime"^^xsd:dateTimeStamp ;
+					odrl:rightOperand "?endDateTime"^^xsd:dateTimeStamp ;
 				] ;
         ( odrl:constraint idsc:CONSTRAINT_TEMPLATE ; )*      # zero or more Constraints
         ( ids:preDuty idsc:OBLIGATION_TEMPLATE ; )*   # zero or more Obligations which need to be fulfilled before the Usage event

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_DURING_INTERVAL_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_DURING_INTERVAL_REQUEST_TEMPLATE.jsonld
@@ -30,7 +30,7 @@
             "@type:" "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
             "odrl:operator": { "@id": "idsc:AFTER" },
-            "ids:rightOperand": {
+            "odrl:rightOperand": {
                 "@value": "?startDateTime",                   // ?startDateTime < ?endDateTime
                 "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
             }
@@ -40,7 +40,7 @@
             "@type:" "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
             "odrl:operator": { "@id": "idsc:BEFORE" },
-            "ids:rightOperand": {
+            "odrl:rightOperand": {
                 "@value": "?endDateTime",
                 "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
             }

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_DURING_INTERVAL_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_DURING_INTERVAL_REQUEST_TEMPLATE.jsonld
@@ -28,8 +28,8 @@
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
-            "ids:operator": { "@id": "idsc:AFTER" },
+            "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
+            "odrl:operator": { "@id": "idsc:AFTER" },
             "ids:rightOperand": {
                 "@value": "?startDateTime",                   // ?startDateTime < ?endDateTime
                 "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
@@ -38,8 +38,8 @@
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
-            "ids:operator": { "@id": "idsc:BEFORE" },
+            "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
+            "odrl:operator": { "@id": "idsc:BEFORE" },
             "ids:rightOperand": {
                 "@value": "?endDateTime",
                 "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_DURING_INTERVAL_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_DURING_INTERVAL_REQUEST_TEMPLATE.jsonld
@@ -24,7 +24,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
         )
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_DURING_INTERVAL_REQUEST_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_DURING_INTERVAL_REQUEST_TEMPLATE.ttl
@@ -41,12 +41,12 @@ idsc:USAGE_DURING_INTERVAL_REQUEST_TEMPLATE a ids:IntervalUsageRequest ;
         odrl:constraint [
 					odrl:leftOperand idsc:POLICY_EVALUATION_TIME ;
 					ids:operator idsc:AFTER ;
-					ids:rightOperand "?startDateTime"^^xsd:dateTimeStamp ; # ?startDateTime < ?endDateTime
+					odrl:rightOperand "?startDateTime"^^xsd:dateTimeStamp ; # ?startDateTime < ?endDateTime
 				] ;
 				odrl:constraint [
 					odrl:leftOperand ids:POLICY_EVALUATION_TIME ;
 					ids:operator idsc:BEFORE ;
-					ids:rightOperand "?endDateTime"^^xsd:dateTimeStamp ;
+					odrl:rightOperand "?endDateTime"^^xsd:dateTimeStamp ;
 				] ;
         ( odrl:constraint idsc:CONSTRAINT_TEMPLATE ; )*      # zero or more Constraints
         ( ids:preDuty idsc:OBLIGATION_TEMPLATE ; )*   # zero or more Obligations which need to be fulfilled before the Usage event

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_DURING_INTERVAL_REQUEST_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_DURING_INTERVAL_REQUEST_TEMPLATE.ttl
@@ -37,7 +37,7 @@ idsc:USAGE_DURING_INTERVAL_REQUEST_TEMPLATE a ids:IntervalUsageRequest ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
 					odrl:leftOperand idsc:POLICY_EVALUATION_TIME ;
 					ids:operator idsc:AFTER ;

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_UNTIL_DELETION_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_UNTIL_DELETION_AGREEMENT_TEMPLATE.jsonld
@@ -12,7 +12,7 @@
         "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:provider,
         "ids:assignee": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:consumer,
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",
@@ -38,8 +38,8 @@
             "@type": "ids:Duty",
             "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),          // same value as ids:provider
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE),          // same value as ids:consumer
-            "ids:action": {
-                "@type": "ids:Action",
+            "odrl:action": {
+                "@type": "odrl:Action",
                 "ids:includedIn": { "@id": "idsc:DELETE" },
                 "ids:actionRefinement": {
                     "@type": "ids:Constraint",

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_UNTIL_DELETION_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_UNTIL_DELETION_AGREEMENT_TEMPLATE.jsonld
@@ -18,7 +18,7 @@
             "@type:" "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
             "odrl:operator": { "@id": "idsc:AFTER" },
-            "ids:rightOperand": {
+            "odrl:rightOperand": {
                 "@value": "?startDateTime",                   // ?startDateTime < ?endDateTime
                 "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
             }
@@ -28,7 +28,7 @@
             "@type:" "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
             "odrl:operator": { "@id": "idsc:BEFORE" },
-            "ids:rightOperand": {
+            "odrl:rightOperand": {
                 "@value": "?endDateTime",
                 "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
             }
@@ -45,7 +45,7 @@
                     "@type": "ids:Constraint",
                     "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
                     "odrl:operator": { "@id": "idsc:TEMPORAL_EQUALS" },
-                    "ids:rightOperand": {
+                    "odrl:rightOperand": {
                         "@value": "?endDateTime",                   // when the interval is over
                         "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
                     }

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_UNTIL_DELETION_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_UNTIL_DELETION_AGREEMENT_TEMPLATE.jsonld
@@ -16,8 +16,8 @@
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
-            "ids:operator": { "@id": "idsc:AFTER" },
+            "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
+            "odrl:operator": { "@id": "idsc:AFTER" },
             "ids:rightOperand": {
                 "@value": "?startDateTime",                   // ?startDateTime < ?endDateTime
                 "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
@@ -26,8 +26,8 @@
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
-            "ids:operator": { "@id": "idsc:BEFORE" },
+            "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
+            "odrl:operator": { "@id": "idsc:BEFORE" },
             "ids:rightOperand": {
                 "@value": "?endDateTime",
                 "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
@@ -43,8 +43,8 @@
                 "ids:includedIn": { "@id": "idsc:DELETE" },
                 "ids:actionRefinement": {
                     "@type": "ids:Constraint",
-                    "ids:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
-                    "ids:operator": { "@id": "idsc:TEMPORAL_EQUALS" },
+                    "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
+                    "odrl:operator": { "@id": "idsc:TEMPORAL_EQUALS" },
                     "ids:rightOperand": {
                         "@value": "?endDateTime",                   // when the interval is over
                         "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_UNTIL_DELETION_AGREEMENT_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_UNTIL_DELETION_AGREEMENT_TEMPLATE.ttl
@@ -25,7 +25,7 @@ idsc:USAGE_UNTIL_DELETION_AGREEMENT_TEMPLATE a ids:DeleteAfterIntervalAgreement 
         odrl:assigner idsc:PARTICIPANT_TEMPLATE ;            # same value as ids:provider
         odrl:assignee idsc:PARTICIPANT_TEMPLATE ;            # same value as ids:consumer
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
 					odrl:leftOperand idsc:POLICY_EVALUATION_TIME ;
 					ids:operator idsc:AFTER ;
@@ -40,7 +40,7 @@ idsc:USAGE_UNTIL_DELETION_AGREEMENT_TEMPLATE a ids:DeleteAfterIntervalAgreement 
             a odrl:Duty ;
             odrl:assigner idsc:PARTICIPANT_TEMPLATE ;        # same value as ids:provider
             odrl:assignee idsc:PARTICIPANT_TEMPLATE ;        # same value as ids:consumer
-            ids:action [
+            odrl:action [
                 a odrl:Action ;
                 odrl:includedIn idsc:DELETE ;
                 ids:actionRefinement [

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_UNTIL_DELETION_AGREEMENT_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_UNTIL_DELETION_AGREEMENT_TEMPLATE.ttl
@@ -29,12 +29,12 @@ idsc:USAGE_UNTIL_DELETION_AGREEMENT_TEMPLATE a ids:DeleteAfterIntervalAgreement 
         odrl:constraint [
 					odrl:leftOperand idsc:POLICY_EVALUATION_TIME ;
 					ids:operator idsc:AFTER ;
-					ids:rightOperand "?startDateTime"^^xsd:dateTimeStamp ;
+					odrl:rightOperand "?startDateTime"^^xsd:dateTimeStamp ;
 				] ;
 				odrl:constraint [
 					odrl:leftOperand ids:POLICY_EVALUATION_TIME ;
 					ids:operator idsc:BEFORE ;
-					ids:rightOperand "?endDateTime"^^xsd:dateTimeStamp ;
+					odrl:rightOperand "?endDateTime"^^xsd:dateTimeStamp ;
 				] ;
         ids:postDuty [
             a odrl:Duty ;
@@ -48,7 +48,7 @@ idsc:USAGE_UNTIL_DELETION_AGREEMENT_TEMPLATE a ids:DeleteAfterIntervalAgreement 
                         a odrl:Constraint ;
                         odrl:leftOperand idsc:POLICY_EVALUATION_TIME ;
                         ids:operator idsc:TEMPORAL_EQUALS ;
-                        ids:rightOperand "?endDateTime"^^xsd:dateTimeStamp ;
+                        odrl:rightOperand "?endDateTime"^^xsd:dateTimeStamp ;
                     ] ;
                 ]
             ] ;

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_UNTIL_DELETION_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_UNTIL_DELETION_OFFER_TEMPLATE.jsonld
@@ -24,7 +24,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
         )
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",
@@ -56,8 +56,8 @@
               ( "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),           // same value as ids:provider
                 "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
             )
-            "ids:action": {
-                "@type": "ids:Action",
+            "odrl:action": {
+                "@type": "odrl:Action",
                 "ids:includedIn": { "@id": "idsc:DELETE" },
                 "ids:actionRefinement": {
                     "@type": "ids:Constraint",

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_UNTIL_DELETION_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_UNTIL_DELETION_OFFER_TEMPLATE.jsonld
@@ -30,7 +30,7 @@
             "@type:" "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
             "odrl:operator": { "@id": "idsc:AFTER" },
-            "ids:rightOperand": {
+            "odrl:rightOperand": {
                 "@value": "?startDateTime",                   // ?startDateTime < ?endDateTime
                 "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
             }
@@ -40,7 +40,7 @@
             "@type:" "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
             "odrl:operator": { "@id": "idsc:BEFORE" },
-            "ids:rightOperand": {
+            "odrl:rightOperand": {
                 "@value": "?endDateTime",
                 "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
             }
@@ -63,7 +63,7 @@
                     "@type": "ids:Constraint",
                     "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
                     "odrl:operator": { "@id": "idsc:TEMPORAL_EQUALS" },
-                    "ids:rightOperand": {
+                    "odrl:rightOperand": {
                         "@value": "?endDateTime",                   // when the interval is over
                         "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
                     }

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_UNTIL_DELETION_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_UNTIL_DELETION_OFFER_TEMPLATE.jsonld
@@ -28,8 +28,8 @@
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
-            "ids:operator": { "@id": "idsc:AFTER" },
+            "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
+            "odrl:operator": { "@id": "idsc:AFTER" },
             "ids:rightOperand": {
                 "@value": "?startDateTime",                   // ?startDateTime < ?endDateTime
                 "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
@@ -38,8 +38,8 @@
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
-            "ids:operator": { "@id": "idsc:BEFORE" },
+            "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
+            "odrl:operator": { "@id": "idsc:BEFORE" },
             "ids:rightOperand": {
                 "@value": "?endDateTime",
                 "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
@@ -61,8 +61,8 @@
                 "ids:includedIn": { "@id": "idsc:DELETE" },
                 "ids:actionRefinement": {
                     "@type": "ids:Constraint",
-                    "ids:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
-                    "ids:operator": { "@id": "idsc:TEMPORAL_EQUALS" },
+                    "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
+                    "odrl:operator": { "@id": "idsc:TEMPORAL_EQUALS" },
                     "ids:rightOperand": {
                         "@value": "?endDateTime",                   // when the interval is over
                         "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_UNTIL_DELETION_OFFER_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_UNTIL_DELETION_OFFER_TEMPLATE.ttl
@@ -37,7 +37,7 @@ idsc:USAGE_UNTIL_DELETION_OFFER_TEMPLATE a ids:DeleteAfterIntervalOffer ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
 					odrl:leftOperand idsc:POLICY_EVALUATION_TIME ;
 					ids:operator idsc:AFTER ;
@@ -58,7 +58,7 @@ idsc:USAGE_UNTIL_DELETION_OFFER_TEMPLATE a ids:DeleteAfterIntervalOffer ;
               (odrl:assigner idsc:PARTICIPANT_TEMPLATE ;         # same value as ids:provider
                odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
             )
-            ids:action [
+            odrl:action [
                 a odrl:Action ;
                 odrl:includedIn idsc:DELETE ;
                 ids:actionRefinement [

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_UNTIL_DELETION_OFFER_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_UNTIL_DELETION_OFFER_TEMPLATE.ttl
@@ -41,12 +41,12 @@ idsc:USAGE_UNTIL_DELETION_OFFER_TEMPLATE a ids:DeleteAfterIntervalOffer ;
         odrl:constraint [
 					odrl:leftOperand idsc:POLICY_EVALUATION_TIME ;
 					ids:operator idsc:AFTER ;
-					ids:rightOperand "?startDateTime"^^xsd:dateTimeStamp ;
+					odrl:rightOperand "?startDateTime"^^xsd:dateTimeStamp ;
 				] ;
 				odrl:constraint [
 					odrl:leftOperand ids:POLICY_EVALUATION_TIME ;
 					ids:operator idsc:BEFORE ;
-					ids:rightOperand "?endDateTime"^^xsd:dateTimeStamp ;
+					odrl:rightOperand "?endDateTime"^^xsd:dateTimeStamp ;
 				] ;
         ids:postDuty [
             a odrl:Duty ;
@@ -66,7 +66,7 @@ idsc:USAGE_UNTIL_DELETION_OFFER_TEMPLATE a ids:DeleteAfterIntervalOffer ;
                         a odrl:Constraint ;
                         odrl:leftOperand idsc:POLICY_EVALUATION_TIME ;
                         ids:operator idsc:TEMPORAL_EQUALS ;
-                        ids:rightOperand "?endDateTime"^^xsd:dateTimeStamp ;
+                        odrl:rightOperand "?endDateTime"^^xsd:dateTimeStamp ;
                     ] ;
                 ]
             ] ;

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_UNTIL_DELETION_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_UNTIL_DELETION_REQUEST_TEMPLATE.jsonld
@@ -24,7 +24,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
         )
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",
@@ -56,8 +56,8 @@
               ( "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),           // same value as ids:provider
                 "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
             )
-            "ids:action": {
-                "@type": "ids:Action",
+            "odrl:action": {
+                "@type": "odrl:Action",
                 "ids:includedIn": { "@id": "idsc:DELETE" },
                 "ids:actionRefinement": {
                     "@type": "ids:Constraint",

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_UNTIL_DELETION_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_UNTIL_DELETION_REQUEST_TEMPLATE.jsonld
@@ -30,7 +30,7 @@
             "@type:" "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
             "odrl:operator": { "@id": "idsc:AFTER" },
-            "ids:rightOperand": {
+            "odrl:rightOperand": {
                 "@value": "?startDateTime",                   // ?startDateTime < ?endDateTime
                 "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
             }
@@ -40,7 +40,7 @@
             "@type:" "ids:Constraint",
             "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
             "odrl:operator": { "@id": "idsc:BEFORE" },
-            "ids:rightOperand": {
+            "odrl:rightOperand": {
                 "@value": "?endDateTime",
                 "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
             }
@@ -63,7 +63,7 @@
                     "@type": "ids:Constraint",
                     "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
                     "odrl:operator": { "@id": "idsc:TEMPORAL_EQUALS" },
-                    "ids:rightOperand": {
+                    "odrl:rightOperand": {
                         "@value": "?endDateTime",                   // when the interval is over
                         "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
                     }

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_UNTIL_DELETION_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_UNTIL_DELETION_REQUEST_TEMPLATE.jsonld
@@ -28,8 +28,8 @@
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
-            "ids:operator": { "@id": "idsc:AFTER" },
+            "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
+            "odrl:operator": { "@id": "idsc:AFTER" },
             "ids:rightOperand": {
                 "@value": "?startDateTime",                   // ?startDateTime < ?endDateTime
                 "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
@@ -38,8 +38,8 @@
         "ids:constraint": [
           {
             "@type:" "ids:Constraint",
-            "ids:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
-            "ids:operator": { "@id": "idsc:BEFORE" },
+            "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
+            "odrl:operator": { "@id": "idsc:BEFORE" },
             "ids:rightOperand": {
                 "@value": "?endDateTime",
                 "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
@@ -61,8 +61,8 @@
                 "ids:includedIn": { "@id": "idsc:DELETE" },
                 "ids:actionRefinement": {
                     "@type": "ids:Constraint",
-                    "ids:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
-                    "ids:operator": { "@id": "idsc:TEMPORAL_EQUALS" },
+                    "odrl:leftOperand": { "@id": "idsc:POLICY_EVALUATION_TIME" },
+                    "odrl:operator": { "@id": "idsc:TEMPORAL_EQUALS" },
                     "ids:rightOperand": {
                         "@value": "?endDateTime",                   // when the interval is over
                         "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_UNTIL_DELETION_REQUEST_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_UNTIL_DELETION_REQUEST_TEMPLATE.ttl
@@ -37,7 +37,7 @@ idsc:USAGE_UNTIL_DELETION_REQUEST_TEMPLATE a ids:DeleteAfterIntervalRequest ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         odrl:constraint [
 					odrl:leftOperand idsc:POLICY_EVALUATION_TIME ;
 					ids:operator idsc:AFTER ;

--- a/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_UNTIL_DELETION_REQUEST_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/TimeRestrictedUsageTemplates/USAGE_UNTIL_DELETION_REQUEST_TEMPLATE.ttl
@@ -41,12 +41,12 @@ idsc:USAGE_UNTIL_DELETION_REQUEST_TEMPLATE a ids:DeleteAfterIntervalRequest ;
         odrl:constraint [
 					odrl:leftOperand idsc:POLICY_EVALUATION_TIME ;
 					ids:operator idsc:AFTER ;
-					ids:rightOperand "?startDateTime"^^xsd:dateTimeStamp ;
+					odrl:rightOperand "?startDateTime"^^xsd:dateTimeStamp ;
 				] ;
 				odrl:constraint [
 					odrl:leftOperand ids:POLICY_EVALUATION_TIME ;
 					ids:operator idsc:BEFORE ;
-					ids:rightOperand "?endDateTime"^^xsd:dateTimeStamp ;
+					odrl:rightOperand "?endDateTime"^^xsd:dateTimeStamp ;
 				] ;
         ids:postDuty [
             a odrl:Duty ;
@@ -66,7 +66,7 @@ idsc:USAGE_UNTIL_DELETION_REQUEST_TEMPLATE a ids:DeleteAfterIntervalRequest ;
                         a odrl:Constraint ;
                         odrl:leftOperand idsc:POLICY_EVALUATION_TIME ;
                         ids:operator idsc:TEMPORAL_EQUALS ;
-                        ids:rightOperand "?endDateTime"^^xsd:dateTimeStamp ;
+                        odrl:rightOperand "?endDateTime"^^xsd:dateTimeStamp ;
                     ] ;
                 ]
             ] ;

--- a/examples/contracts-and-usage-policy/templates/UsageLoggingTemplates/USAGE_LOGGING_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/UsageLoggingTemplates/USAGE_LOGGING_AGREEMENT_TEMPLATE.jsonld
@@ -28,7 +28,7 @@
 					"@type":"ids:Constraint",  
 					"odrl:leftOperand": { "@id": "idsc:LOG_LEVEL"},
 					"odrl:operator": { "@id": "idsc:DEFINES_AS"},
-					"ids:rightOperand": { "@value": ["idsc:LOG_ON_ALLOW", "idsc:LOG_ON_DENY"] }
+					"odrl:rightOperand": { "@value": ["idsc:LOG_ON_ALLOW", "idsc:LOG_ON_DENY"] }
 				  }] 
 			}, 
         	"ids:PXPEndpoint": { "@id": "https//example.com/pxp/log" }

--- a/examples/contracts-and-usage-policy/templates/UsageLoggingTemplates/USAGE_LOGGING_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/UsageLoggingTemplates/USAGE_LOGGING_AGREEMENT_TEMPLATE.jsonld
@@ -26,8 +26,8 @@
 					"rightOperand": { "@value": "https//example.com/logging_system_device", "@type": "xsd:anyURI"} 
 				},{    
 					"@type":"ids:Constraint",  
-					"ids:leftOperand": { "@id": "idsc:LOG_LEVEL"},  
-					"ids:operator": { "@id": "idsc:DEFINES_AS"},  
+					"odrl:leftOperand": { "@id": "idsc:LOG_LEVEL"},
+					"odrl:operator": { "@id": "idsc:DEFINES_AS"},
 					"ids:rightOperand": { "@value": ["idsc:LOG_ON_ALLOW", "idsc:LOG_ON_DENY"] }
 				  }] 
 			}, 

--- a/examples/contracts-and-usage-policy/templates/UsageLoggingTemplates/USAGE_LOGGING_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/UsageLoggingTemplates/USAGE_LOGGING_AGREEMENT_TEMPLATE.jsonld
@@ -12,12 +12,12 @@
         "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:provider,
         "ids:assignee": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:consumer,
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:postDuty": {
             "@type": "ids:Duty",
             "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),          // same value as ids:provider
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE),          // same value as ids:consumer
-            "ids:action": { 
+            "odrl:action": {
 				"@id": "idsc:LOG",
 				"ids:actionRefinement": [{   
 					"@type":"ids:Constraint",

--- a/examples/contracts-and-usage-policy/templates/UsageLoggingTemplates/USAGE_LOGGING_AGREEMENT_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/UsageLoggingTemplates/USAGE_LOGGING_AGREEMENT_TEMPLATE.ttl
@@ -25,12 +25,12 @@ idsc:USAGE_LOGGING_AGREEMENT_TEMPLATE a ids:LoggingAgreement ;
         odrl:assigner idsc:PARTICIPANT_TEMPLATE ;            # same value as ids:provider
         odrl:assignee idsc:PARTICIPANT_TEMPLATE ;            # same value as ids:consumer
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         ids:postDuty [
             a odrl:Duty ;
             odrl:assigner idsc:PARTICIPANT_TEMPLATE ;        # same value as ids:provider
             odrl:assignee idsc:PARTICIPANT_TEMPLATE ;        # same value as ids:consumer
-            ids:action idsc:LOG ;
+            odrl:action idsc:LOG ;
         ] ;
         ( odrl:constraint idsc:CONSTRAINT_TEMPLATE ; )*      # zero or more Constraints
         ( ids:preDuty idsc:OBLIGATION_TEMPLATE ; )*   # zero or more Obligations which need to be fulfilled before the Usage event

--- a/examples/contracts-and-usage-policy/templates/UsageLoggingTemplates/USAGE_LOGGING_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/UsageLoggingTemplates/USAGE_LOGGING_OFFER_TEMPLATE.jsonld
@@ -24,7 +24,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
         )
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:postDuty": {
             "@type": "ids:Duty",
             (
@@ -35,7 +35,7 @@
               ( "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),           // same value as ids:provider
                 "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
             )
-            "ids:action": { "@id": "idsc:LOG" }
+            "odrl:action": { "@id": "idsc:LOG" }
         }
         (, "ids:constraint": (idsc:CONSTRAINT_TEMPLATE) )*        // zero or more Constraints
         (, "ids:preDuty": (idsc:OBLIGATION_TEMPLATE) )*     // zero or more Obligations which need to be fulfilled before the Usage event

--- a/examples/contracts-and-usage-policy/templates/UsageLoggingTemplates/USAGE_LOGGING_OFFER_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/UsageLoggingTemplates/USAGE_LOGGING_OFFER_TEMPLATE.ttl
@@ -37,7 +37,7 @@ idsc:USAGE_LOGGING_OFFER_TEMPLATE a ids:LoggingOffer ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         ids:postDuty [
             a odrl:Duty ;
             (
@@ -48,7 +48,7 @@ idsc:USAGE_LOGGING_OFFER_TEMPLATE a ids:LoggingOffer ;
               (odrl:assigner idsc:PARTICIPANT_TEMPLATE ;         # same value as ids:provider
                odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
             )
-            ids:action idsc:LOG ;
+            odrl:action idsc:LOG ;
         ] ;
         ( odrl:constraint idsc:CONSTRAINT_TEMPLATE ; )*      # zero or more Constraints
         ( ids:preDuty idsc:OBLIGATION_TEMPLATE ; )*   # zero or more Obligations which need to be fulfilled before the Usage event

--- a/examples/contracts-and-usage-policy/templates/UsageLoggingTemplates/USAGE_LOGGING_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/UsageLoggingTemplates/USAGE_LOGGING_REQUEST_TEMPLATE.jsonld
@@ -24,7 +24,7 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
         )
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:postDuty": {
             "@type": "ids:Duty",
             (
@@ -35,7 +35,7 @@
               ( "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),           // same value as ids:provider
                 "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
             )
-            "ids:action": { "@id": "idsc:LOG" }
+            "odrl:action": { "@id": "idsc:LOG" }
         }
         (, "ids:constraint": (idsc:CONSTRAINT_TEMPLATE) )*        // zero or more Constraints
         (, "ids:preDuty": (idsc:OBLIGATION_TEMPLATE) )*     // zero or more Obligations which need to be fulfilled before the Usage event

--- a/examples/contracts-and-usage-policy/templates/UsageLoggingTemplates/USAGE_LOGGING_REQUEST_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/UsageLoggingTemplates/USAGE_LOGGING_REQUEST_TEMPLATE.ttl
@@ -37,7 +37,7 @@ idsc:USAGE_LOGGING_REQUEST_TEMPLATE a ids:LoggingRequest ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         ids:postDuty [
             a odrl:Duty ;
             (
@@ -48,7 +48,7 @@ idsc:USAGE_LOGGING_REQUEST_TEMPLATE a ids:LoggingRequest ;
               (odrl:assigner idsc:PARTICIPANT_TEMPLATE ;         # same value as ids:provider
                odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
             )
-            ids:action idsc:LOG ;
+            odrl:action idsc:LOG ;
         ] ;
         ( odrl:constraint idsc:CONSTRAINT_TEMPLATE ; )*      # zero or more Constraints
         ( ids:preDuty idsc:OBLIGATION_TEMPLATE ; )*   # zero or more Obligations which need to be fulfilled before the Usage event

--- a/examples/contracts-and-usage-policy/templates/UsageNotificationTemplates/USAGE_NOTIFICATION_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/UsageNotificationTemplates/USAGE_NOTIFICATION_AGREEMENT_TEMPLATE.jsonld
@@ -12,11 +12,11 @@
         "ids:assigner": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:provider,
         "ids:assignee": (idsc:PARTICIPANT_TEMPLATE),              // same value as ids:consumer,
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:postDuty": [ {
             "@type": "ids:Duty",
-            "ids:action": {
-                "@type": "ids:Action",
+            "odrl:action": {
+                "@type": "odrl:Action",
                 "ids:includedIn": { "@id": "idsc:NOTIFY" },
                 "ids:actionRefinement": {
                     "@type": "ids:Constraint",

--- a/examples/contracts-and-usage-policy/templates/UsageNotificationTemplates/USAGE_NOTIFICATION_AGREEMENT_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/UsageNotificationTemplates/USAGE_NOTIFICATION_AGREEMENT_TEMPLATE.jsonld
@@ -20,8 +20,8 @@
                 "ids:includedIn": { "@id": "idsc:NOTIFY" },
                 "ids:actionRefinement": {
                     "@type": "ids:Constraint",
-                    "ids:leftOperand": { "@id": "idsc:ENDPOINT" },
-                    "ids:operator": { "@id": "idsc:DEFINES_AS" },
+                    "odrl:leftOperand": { "@id": "idsc:ENDPOINT" },
+                    "odrl:operator": { "@id": "idsc:DEFINES_AS" },
                     "ids:rightOperandReference": { "@id": "?notificationEndpointUrl" }  // Send notification information to this URL
                 }
             }

--- a/examples/contracts-and-usage-policy/templates/UsageNotificationTemplates/USAGE_NOTIFICATION_AGREEMENT_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/UsageNotificationTemplates/USAGE_NOTIFICATION_AGREEMENT_TEMPLATE.ttl
@@ -25,10 +25,10 @@ idsc:USAGE_NOTIFICATION_AGREEMENT_TEMPLATE a ids:NotificationAgreement ;
         odrl:assigner idsc:PARTICIPANT_TEMPLATE ;
         odrl:assignee idsc:PARTICIPANT_TEMPLATE ;
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         ids:postDuty [
             a odrl:Duty ;
-            ids:action [
+            odrl:action [
                 a odrl:Action ;
                 odrl:includedIn idsc:NOTIFY ;
                 ids:actionRefinement [

--- a/examples/contracts-and-usage-policy/templates/UsageNotificationTemplates/USAGE_NOTIFICATION_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/UsageNotificationTemplates/USAGE_NOTIFICATION_OFFER_TEMPLATE.jsonld
@@ -32,8 +32,8 @@
                 "ids:includedIn": { "@id": "idsc:NOTIFY" },
                 "ids:actionRefinement": {
                     "@type": "ids:Constraint",
-                    "ids:leftOperand": { "@id": "idsc:ENDPOINT" },
-                    "ids:operator": { "@id": "idsc:DEFINES_AS" },
+                    "odrl:leftOperand": { "@id": "idsc:ENDPOINT" },
+                    "odrl:operator": { "@id": "idsc:DEFINES_AS" },
                     "ids:rightOperandReference": { "@id": "?notificationEndpointUrl" }  // Send notification information to this URL
                 }
             }

--- a/examples/contracts-and-usage-policy/templates/UsageNotificationTemplates/USAGE_NOTIFICATION_OFFER_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/UsageNotificationTemplates/USAGE_NOTIFICATION_OFFER_TEMPLATE.jsonld
@@ -24,11 +24,11 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
         )
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:postDuty": [ {
             "@type": "ids:Duty",
-            "ids:action": {
-                "@type": "ids:Action",
+            "odrl:action": {
+                "@type": "odrl:Action",
                 "ids:includedIn": { "@id": "idsc:NOTIFY" },
                 "ids:actionRefinement": {
                     "@type": "ids:Constraint",

--- a/examples/contracts-and-usage-policy/templates/UsageNotificationTemplates/USAGE_NOTIFICATION_OFFER_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/UsageNotificationTemplates/USAGE_NOTIFICATION_OFFER_TEMPLATE.ttl
@@ -37,10 +37,10 @@ idsc:USAGE_NOTIFICATION_OFFER_TEMPLATE a ids:NotificationOffer ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         ids:postDuty [
             a odrl:Duty ;
-            ids:action [
+            odrl:action [
                 a odrl:Action ;
                 odrl:includedIn idsc:NOTIFY ;
                 ids:actionRefinement [

--- a/examples/contracts-and-usage-policy/templates/UsageNotificationTemplates/USAGE_NOTIFICATION_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/UsageNotificationTemplates/USAGE_NOTIFICATION_REQUEST_TEMPLATE.jsonld
@@ -32,8 +32,8 @@
                 "ids:includedIn": { "@id": "idsc:NOTIFY" },
                 "ids:actionRefinement": {
                     "@type": "ids:Constraint",
-                    "ids:leftOperand": { "@id": "idsc:ENDPOINT" },
-                    "ids:operator": { "@id": "idsc:DEFINES_AS" },
+                    "odrl:leftOperand": { "@id": "idsc:ENDPOINT" },
+                    "odrl:operator": { "@id": "idsc:DEFINES_AS" },
                     "ids:rightOperandReference": { "@id": "?notificationEndpointUrl" }  // Send notification information to this URL
                 }
             }

--- a/examples/contracts-and-usage-policy/templates/UsageNotificationTemplates/USAGE_NOTIFICATION_REQUEST_TEMPLATE.jsonld
+++ b/examples/contracts-and-usage-policy/templates/UsageNotificationTemplates/USAGE_NOTIFICATION_REQUEST_TEMPLATE.jsonld
@@ -24,11 +24,11 @@
             "ids:assignee": (idsc:PARTICIPANT_TEMPLATE), )         // same value as ids:consumer
         )
         "ids:target": (idsc:ASSET_TEMPLATE),
-        "ids:action": (idsc:ACTION_TEMPLATE),
+        "odrl:action": (idsc:ACTION_TEMPLATE),
         "ids:postDuty": [ {
             "@type": "ids:Duty",
-            "ids:action": {
-                "@type": "ids:Action",
+            "odrl:action": {
+                "@type": "odrl:Action",
                 "ids:includedIn": { "@id": "idsc:NOTIFY" },
                 "ids:actionRefinement": {
                     "@type": "ids:Constraint",

--- a/examples/contracts-and-usage-policy/templates/UsageNotificationTemplates/USAGE_NOTIFICATION_REQUEST_TEMPLATE.ttl
+++ b/examples/contracts-and-usage-policy/templates/UsageNotificationTemplates/USAGE_NOTIFICATION_REQUEST_TEMPLATE.ttl
@@ -37,10 +37,10 @@ idsc:USAGE_NOTIFICATION_REQUEST_TEMPLATE a ids:NotificationRequest ;
            odrl:assignee idsc:PARTICIPANT_TEMPLATE ;)        # same value as ids:consumer
         )
         ids:target idsc:ASSET_TEMPLATE ;
-        ids:action idsc:ACTION_TEMPLATE ;
+        odrl:action idsc:ACTION_TEMPLATE ;
         ids:postDuty [
             a odrl:Duty ;
-            ids:action [
+            odrl:action [
                 a odrl:Action ;
                 odrl:includedIn idsc:NOTIFY ;
                 ids:actionRefinement [

--- a/examples/domain-specific-semantics-using-SHACL/TEMP_RESOURCE.json
+++ b/examples/domain-specific-semantics-using-SHACL/TEMP_RESOURCE.json
@@ -81,7 +81,7 @@
                 "constraint": {
                     "@type": "ids:Constraint",
                     "leftOperand": {
-                        "@type": "ids:LeftOperand",
+                        "@type": "odrl:LeftOperand",
                         "@id": "https://w3id.org/idsa/code/now"
                     },
                     "operator": {
@@ -98,7 +98,7 @@
                     "constraint": {
                         "@type": "ids:Constraint",
                         "leftOperand": {
-                            "@type": "ids:LeftOperand",
+                            "@type": "odrl:LeftOperand",
                             "@id": "https://w3id.org/idsa/code/payAmount"
                         },
 

--- a/examples/domain-specific-semantics-using-SHACL/TEMP_RESOURCE.json
+++ b/examples/domain-specific-semantics-using-SHACL/TEMP_RESOURCE.json
@@ -73,7 +73,7 @@
         "permission": [{
                 "@type": "ids:Permission",
                 "action": {
-                    "@type": "ids:Action",
+                    "@type": "odrl:Action",
                     "@id": "https://w3id.org/idsa/code/USE"
                 },
                 "assigner": "<Assigner Participant URI>",

--- a/examples/domain-specific-semantics-using-SHACL/TEMP_RESOURCE.ttl
+++ b/examples/domain-specific-semantics-using-SHACL/TEMP_RESOURCE.ttl
@@ -81,7 +81,7 @@ sample_Data:
             a odrl:Permission ;
 
             # Specify permission
-            ids:action idsc:USE ;
+            odrl:action idsc:USE ;
             odrl:assigner "<URI of the provider IDS participant>";
 
             # Individual target artifact(s)
@@ -97,7 +97,7 @@ sample_Data:
 
             # Obligation / Duty
             ids:preDuty [
-                ids:action idsc:COMPENSATE ;
+                odrl:action idsc:COMPENSATE ;
                 odrl:constraint [
                     odrl:leftOperand idsc:payAmount ;
                       ids:operator ids:EQ ;

--- a/examples/domain-specific-semantics-using-SHACL/TEMP_RESOURCE.ttl
+++ b/examples/domain-specific-semantics-using-SHACL/TEMP_RESOURCE.ttl
@@ -92,7 +92,7 @@ sample_Data:
                 a odrl:Constraint ;
                 odrl:leftOperand idsc:now;
                 ids:operator idsc:IN_TIME_INTERVAL ;
-                ids:rightOperand "[ids:hasBeginning {2019-10-01T00:00:01Z}; ids:hasEnding {2019-10-13T23:59:59Z} ]";
+                odrl:rightOperand "[ids:hasBeginning {2019-10-01T00:00:01Z}; ids:hasEnding {2019-10-13T23:59:59Z} ]";
                 ] ;
 
             # Obligation / Duty
@@ -101,7 +101,7 @@ sample_Data:
                 odrl:constraint [
                     odrl:leftOperand idsc:payAmount ;
                       ids:operator ids:EQ ;
-                      ids:rightOperand 100 ;
+                      odrl:rightOperand 100 ;
                       odrl:unit <http://dbpedia.org/resource/Euro>;
                 ]
             ]

--- a/model/contract/Constraint.ttl
+++ b/model/contract/Constraint.ttl
@@ -10,13 +10,6 @@
 # Properties
 # ----------
 
-ids:rightOperand rdfs:subPropertyOf odrl:rightOperand;
-    a owl:ObjectProperty;
-    rdfs:label "rightOperand"@en ;
-    rdfs:domain odrl:Constraint;
-    rdfs:range rdfs:Resource;
-    rdfs:comment "The value of the right operand in a constraint expression. Value should be a rdfs:Resource or literal values. Either ids:rightOperand or odrl:rightOperandReference should be used in an odrl:Constraint."@en.
-
 ids:pipEndpoint a owl:ObjectProperty;
      rdfs:label "has PIP endpoint"@en;
      rdfs:domain odrl:Constraint;

--- a/model/contract/Rule.ttl
+++ b/model/contract/Rule.ttl
@@ -9,15 +9,6 @@
 # Properties
 # ----------
 
-ids:action
-    rdfs:subPropertyOf odrl:action;
-    a owl:ObjectProperty;
-    rdfs:label "action"@en;
-    rdfs:domain [ rdf:type owl:Class ;
-			owl:unionOf ( odrl:Rule ids:UsageControlObject)] ;
-    rdfs:range odrl:Action;
-    rdfs:comment "The operation relating to the asset / data object. "@en.
-
 ids:target
     a owl:ObjectProperty;
     rdfs:domain odrl:Rule;

--- a/testing/content/ResourceShape.ttl
+++ b/testing/content/ResourceShape.ttl
@@ -67,7 +67,7 @@ shapes:ResourceShape
 
 	sh:property [
 		a sh:PropertyShape ;
-		sh:path ids:publisher ;
+		sh:path dct:publisher ;
 		sh:or (
 	    [ sh:class ids:Agent ; sh:order 1 ; ]
 	    [ sh:nodeKind sh:IRI ; sh:order 2 ; ]

--- a/testing/content/UsageControlObjectShape.ttl
+++ b/testing/content/UsageControlObjectShape.ttl
@@ -83,10 +83,10 @@ shapes:UsageControlObjectShape
 
 	sh:property [
 		a sh:PropertyShape ;
-		sh:path ids:action ;
+		sh:path odrl:action ;
 		sh:class odrl:Action ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/content/UsageControlObjectShape.ttl> (UsageControlObjectShape): An ids:action property must point from an ids:UsageControlObject to an odrl:Action."@en ;
+		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/content/UsageControlObjectShape.ttl> (UsageControlObjectShape): An odrl:action property must point from an ids:UsageControlObject to an odrl:Action."@en ;
 	] ;
 
 	sh:property [

--- a/testing/contract/ActionShape.ttl
+++ b/testing/contract/ActionShape.ttl
@@ -39,6 +39,6 @@ shapes:ActionShape
 		sh:minCount 0 ;
 		sh:maxCount 1 ;
  		sh:severity sh:Violation ;
- 		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/contract/ActionShape.ttl> (ActionShape): An ids:pxpEndpoint property must have an ids:Action to an ids:PXP."@en ;
+ 		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/contract/ActionShape.ttl> (ActionShape): An ids:pxpEndpoint property must have an odrl:Action to an ids:PXP."@en ;
  	] ;
 .

--- a/testing/contract/ConstraintShape.ttl
+++ b/testing/contract/ConstraintShape.ttl
@@ -22,26 +22,6 @@ shapes:
 		sh:namespace "https://w3id.org/idsa/core/"^^xsd:anyURI ;
 	] .
 
-
-shapes:AbstractConstraintShape
-	a sh:NodeShape ;
-	sh:targetClass odrl:Constraint ;
-
-	sh:sparql [
-		a sh:SPARQLConstraint ;
-		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/contract/ContractShape.ttl> (AbstractConstraintShape): An odrl:Constraint is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
-		sh:prefixes shapes: ;
-		sh:select """
-			SELECT ?this ?type
-			WHERE {
-				?this rdf:type ?type .
-				FILTER (?type = odrl:Constraint)
-			}
-		""" ;
-	] ;
-.
-
-
 shapes:ConstraintShape
 	a sh:NodeShape ;
 	sh:targetClass odrl:Constraint ;

--- a/testing/contract/ConstraintShape.ttl
+++ b/testing/contract/ConstraintShape.ttl
@@ -50,11 +50,11 @@ shapes:ConstraintShape
     [
 			sh:property [
 				a sh:PropertyShape ;
-	    	sh:path ids:rightOperand ;
+	    	sh:path odrl:rightOperand ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:severity sh:Violation ;
-				sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/contract/ConstraintShape.ttl> (ConstraintShape): Exactly one ids:rightOperand property must point from an ids::Constraint to Literals or rdfs:Resources. Note that ids:rightOperand and odrl:rightOperandReference cannot be used in the same statement."@en ;
+				sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/contract/ConstraintShape.ttl> (ConstraintShape): Exactly one odrl:rightOperand property must point from an ids::Constraint to Literals or rdfs:Resources. Note that odrl:rightOperand and odrl:rightOperandReference cannot be used in the same statement."@en ;
 			]
 		]
     [
@@ -65,7 +65,7 @@ shapes:ConstraintShape
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:severity sh:Violation ;
-				sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/contract/ConstraintShape.ttl> (ConstraintShape): Exactly one odrl:rightOperandReference property must point from an ids::Constraint to an IRI. Note that ids:rightOperand and odrl:rightOperandReference cannot be used in the same statement."@en ;
+				sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/contract/ConstraintShape.ttl> (ConstraintShape): Exactly one odrl:rightOperandReference property must point from an ids::Constraint to an IRI. Note that odrl:rightOperand and odrl:rightOperandReference cannot be used in the same statement."@en ;
 			]
 		]
 	) ;

--- a/testing/contract/RuleShape.ttl
+++ b/testing/contract/RuleShape.ttl
@@ -41,11 +41,11 @@ shapes:RuleShape
 
 	sh:property [
 		a sh:PropertyShape ;
-		sh:path ids:action ;
+		sh:path odrl:action ;
 		sh:class odrl:Action ;
 		sh:minCount 1 ;
 		sh:severity sh:Violation ;
-		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/contract/RuleShape.ttl> (RuleShape): An odrl:Rule must have at least one odrl:Action linked through the ids:action property"@en ;
+		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/contract/RuleShape.ttl> (RuleShape): An odrl:Rule must have at least one odrl:Action linked through the odrl:action property"@en ;
 	] ;
 
 	sh:property [

--- a/utils/refactor_helper.ttl
+++ b/utils/refactor_helper.ttl
@@ -52,8 +52,7 @@ dct:DCMIType
 dct:MediaType
     a owl:Class ;
     rdfs:label "Media Type"@en ; 
-    rdfs:comment "General class of media types (formerly known as MIME types).  is used only when no ids:IANAMediaType available."@en .
-
+    rdfs:comment "General class of media types (formerly known as MIME types). It is used only when no ids:IANAMediaType available."@en .
 
 dcat:Distribution
     a rdfs:Class ;
@@ -198,7 +197,7 @@ foaf:mbox
     a owl:ObjectProperty ;   
     a owl:InverseFunctionalProperty ;
     rdfs:label "personal mailbox"@en ;
-    rdfs:domain ids:Participant;
+    rdfs:domain [ owl:unionOf (ids:Participant foaf:Person) ];
     rdfs:range xsd:string;
     rdfs:comment "Email address for contacting the participant on a general level."@en .
 
@@ -206,7 +205,7 @@ foaf:homepage
     a owl:ObjectProperty ;  
     a owl:InverseFunctionalProperty ;
     rdfs:label "homepage"@en ;
-    rdfs:domain ids:Participant;
+    rdfs:domain [ owl:unionOf (ids:Participant foaf:Person) ];
     rdfs:range xsd:anyURI;
     rdfs:comment "General official homepage of the participant."@en .
 

--- a/utils/refactor_helper.ttl
+++ b/utils/refactor_helper.ttl
@@ -151,6 +151,14 @@ odrl:Action
     rdfs:label "Action"@en ;
     rdfs:comment "A thing one might be permitted to do or prohibited from doing to something."@en .
 
+odrl:action
+    a owl:ObjectProperty;
+    rdfs:label "action"@en;
+    rdfs:domain [ rdf:type owl:Class ;
+                  owl:unionOf ( odrl:Rule ids:UsageControlObject)] ;
+    rdfs:range odrl:Action;
+    rdfs:comment "The operation relating to the asset / data object. "@en.
+
 dcat:Catalog
     a rdfs:Class ;
     a owl:Class ;

--- a/utils/refactor_helper.ttl
+++ b/utils/refactor_helper.ttl
@@ -383,6 +383,13 @@ odrl:leftOperand
     rdfs:range odrl:LeftOperand ;
     rdfs:comment "The left operand in a constraint expression."@en .
 
+odrl:rightOperand
+    a rdf:Property ;
+    rdfs:label "rightOperand"@en ;
+    rdfs:domain odrl:Constraint;
+    rdfs:range rdfs:Resource;
+    rdfs:comment "The value of the right operand in a constraint expression. Value should be a rdfs:Resource or literal values. Either odrl:rightOperand or odrl:rightOperandReference should be used in an odrl:Constraint."@en.
+
 odrl:operator
     a rdf:Property ; 
     a owl:ObjectProperty ; 
@@ -396,7 +403,7 @@ odrl:rightOperandReference
     rdfs:label "Has Right Operand Reference"@en ;
     rdfs:domain odrl:Constraint;
     rdfs:range rdfs:Resource;
-    rdfs:comment "The reference IRI of the right operand in a constraint expression. Has to be dereferenced in order to receive the actual value. Either ids:rightOperand or ids:rightOperandReference should be used in an odrl:Constraint."@en .
+    rdfs:comment "The reference IRI of the right operand in a constraint expression. Has to be dereferenced in order to receive the actual value. Either odrl:rightOperand or ids:rightOperandReference should be used in an odrl:Constraint."@en .
 
 odrl:unit
     a rdf:Property ; 


### PR DESCRIPTION
Pascal checked the situation regarding the current develop branch of the InformationModel and have found the following small issues:

- codes/Action.ttl has some instances of ids:Action which does not exist anymore. Should be odrl:Action.
- codes/LeftOperand.ttl has some instances of ids:LeftOperand which does not exist anymore. Should be odrl:LeftOperand.
- testing/content/ResourceShape.ttl line 70 we now need dct:publisher instead of ids:publisher
- testing/contract/ConstraintShape.ttl lines 26-42: AbstractConstraint should be removed? Or not have targetClass odrl:Constraint?
- (minor note: utils/refactor_helper.ttl dct:MediaType comment is missing a noun in the second sentence.)
- testing/participant/ParticipantShape.ttl (PersonShape) contains foaf:mbox and foaf:homepage as properties but the properties do not have foaf:Person as domain and Person is no subclass of foaf:Participant. Is this supposed to be this way? The "old" ids:Person had an emailAddress and a homepage. Currently, this is not the case due to the described situation.