### PR TITLE
Add DQV Support

### DIFF
--- a/codes/QualityMetrics.ttl
+++ b/codes/QualityMetrics.ttl
@@ -8,7 +8,7 @@
 # Dimensions
 # ---------
 
-idsc:availability
+idsc:AVAILABILITY
     a dqv:Dimension ;
     rdfs:label "Availability" ;
     skos:definition "Availability of a dataset: Is the data present, obtainable and ready for use?"@en .
@@ -17,8 +17,8 @@ idsc:availability
 # Metrics
 # ---------
 
-idsc:downloadURLAvailabilityMetric 
+idsc:DOWNLOAD_URL_AVAILABILITY_METRIC
     a dqv:Metric ;
     skos:definition "Checks if all ResourceEndpoints for given resource are available and dereferenceable."@en ;
     dqv:expectedDataType xsd:boolean ;
-    dqv:inDimension idsc:availability .
+    dqv:inDimension idsc:AVAILABILITY .

--- a/codes/QualityMetrics.ttl
+++ b/codes/QualityMetrics.ttl
@@ -1,0 +1,24 @@
+@prefix ids: <https://w3id.org/idsa/core/> .
+@prefix idsc: <https://w3id.org/idsa/code/> .
+@prefix dqv: <http://www.w3.org/ns/dqv#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+
+# Dimensions
+# ---------
+
+idsc:availability
+    a dqv:Dimension ;
+    rdfs:label "Availability" ;
+    skos:definition "Availability of a dataset: Is the data present, obtainable and ready for use?"@en .
+
+
+# Metrics
+# ---------
+
+idsc:downloadURLAvailabilityMetric 
+    a dqv:Metric ;
+    skos:definition "Checks if all ResourceEndpoints for given resource are available and dereferenceable."@en ;
+    dqv:expectedDataType xsd:boolean ;
+    dqv:inDimension idsc:availability .

--- a/codes/QualityMetrics.ttl
+++ b/codes/QualityMetrics.ttl
@@ -3,7 +3,7 @@
 @prefix dqv: <http://www.w3.org/ns/dqv#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
 # Dimensions
 # ---------

--- a/examples/DATA3.ttl
+++ b/examples/DATA3.ttl
@@ -3,6 +3,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix odrl: <http://www.w3.org/ns/odrl/2/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dqv: <http://www.w3.org/ns/dqv#> .
 
 @prefix conn3: <https://aastat.gov.de/connector/conn3/> .
 @prefix data3: <https://aastat.gov.de/connector/conn3/data3/> .
@@ -46,6 +47,13 @@ data3:
         a ids:ConnectorEndpoint ;
         ids:endpointArtifact data3:report_doc ;
         ids:accessURL <https://connector.aastat.gov.de/reports/Highway_traffic_statistics.doc> ;
+    ] ;
+
+    # Data Quality
+    dqv:hasQualityMeasurement [
+        a dqv:QualityMeasurement ;
+        dqv:isMeasurementOf idsc:downloadURLAvailabilityMetric ;
+        dqv:value "true"^^xsd:boolean ;
     ] ;
 
     # Commodization

--- a/testing/content/ResourceShape.ttl
+++ b/testing/content/ResourceShape.ttl
@@ -7,6 +7,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix shapes: <https://github.com/International-Data-Spaces-Association/InformationModel/tree/master/testing/> .
+@prefix dqv: <http://www.w3.org/ns/dqv#> .
 
 shapes:
 	a owl:Ontology ;
@@ -104,6 +105,14 @@ shapes:ResourceShape
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/content/ResourceShape.ttl> (ResourceShape): An ids:variant property must not have more than one point from an ids:Resource to an ids:Resource."@en ;
+	] ;
+
+	sh:property [
+		a sh:PropertyShape ;
+		sh:path dqv:hasQualityMeasurement ;
+		sh:class dqv:QualityMeasurement ;		
+		sh:severity sh:Violation ;
+		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/content/ResourceShape.ttl> (ResourceShape): A dqv:hasQualityMeasurement property must point from an ids:Resource to a dqv:QualityMeasurement."@en ;
 	] ;
 
 .


### PR DESCRIPTION
To express the quality of resources, the [DQV vocabulary](https://www.w3.org/TR/vocab-dqv/) is used.