### PR TITLE
Fixed prefixes of SPRQL queries in the shapes

### DIFF
--- a/testing/content/AssetShape.ttl
+++ b/testing/content/AssetShape.ttl
@@ -18,8 +18,8 @@ shapes:
 	] ;
 
 	sh:declare [
-		sh:prefix "ids" ;
-		sh:namespace "https://w3id.org/idsa/core/"^^xsd:anyURI ;
+		sh:prefix "odrl" ;
+		sh:namespace "http://www.w3.org/ns/odrl/2/"^^xsd:anyURI ;
 	] .
 
 
@@ -54,7 +54,7 @@ shapes:AssetCollectionShape
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/content/AssetShape.ttl> (AssetCollectionShape): An ids:assetSource property must not have more than one point from an odrl:AssetCollection to an IRI."@en ;
 	] ;
-	
+
 	sh:property [
 		 a sh:PropertyShape ;
 		 sh:path odrl:refinement ;

--- a/testing/content/ConceptShape.ttl
+++ b/testing/content/ConceptShape.ttl
@@ -18,13 +18,13 @@ shapes:
 	] ;
 
 	sh:declare [
-		sh:prefix "ids" ;
-		sh:namespace "https://w3id.org/idsa/core/"^^xsd:anyURI ;
+		sh:prefix "skos" ;
+		sh:namespace "http://www.w3.org/2004/02/skos/core#"^^xsd:anyURI ;
 	] .
 
 
 shapes:ConceptShape
-	a sh:NodeShape ; 
+	a sh:NodeShape ;
 	sh:targetClass skos:Concept ;
 
 	sh:sparql [
@@ -39,4 +39,3 @@ shapes:ConceptShape
 			}
 		""" ;
 	] .
-

--- a/testing/content/MediaTypeShape.ttl
+++ b/testing/content/MediaTypeShape.ttl
@@ -15,8 +15,8 @@ shapes:
 	] ;
 
 	sh:declare [
-		sh:prefix "ids" ;
-		sh:namespace "https://w3id.org/idsa/core/"^^xsd:anyURI ;
+		sh:prefix "dct" ;
+		sh:namespace "http://purl.org/dc/terms/"^^xsd:anyURI ;
 	] .
 
 

--- a/testing/contract/RuleShape.ttl
+++ b/testing/contract/RuleShape.ttl
@@ -17,8 +17,8 @@ shapes:
 	] ;
 
 	sh:declare [
-		sh:prefix "ids" ;
-		sh:namespace "https://w3id.org/idsa/core/"^^xsd:anyURI ;
+		sh:prefix "odrl" ;
+		sh:namespace "http://www.w3.org/ns/odrl/2/"^^xsd:anyURI ;
 	] .
 
 

--- a/testing/infrastructure/CatalogShape.ttl
+++ b/testing/infrastructure/CatalogShape.ttl
@@ -16,8 +16,8 @@ shapes:
 	] ;
 
 	sh:declare [
-		sh:prefix "ids" ;
-		sh:namespace "https://w3id.org/idsa/core/"^^xsd:anyURI ;
+		sh:prefix "dcat" ;
+		sh:namespace "http://www.w3.org/ns/dcat#"^^xsd:anyURI ;
 	] .
 
 


### PR DESCRIPTION
Missing prefixes of external ontologies in the SPARQL queries in some Shacl Shapes