### PR TITLE
Make the pipEndpoint optional

### DIFF
--- a/testing/contract/ConstraintShape.ttl
+++ b/testing/contract/ConstraintShape.ttl
@@ -41,33 +41,33 @@ shapes:ConstraintShape
 		sh:path odrl:operator ;
 		sh:class ids:BinaryOperator ;
 		sh:minCount 1 ;
-    sh:maxCount 1 ;
+    		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/contract/ConstraintShape.ttl> (ConstraintShape): An odrl:Constraint must have  exactly one ids:BinaryOperator linked through the odrl:operator property"@en ;
 	] ;
 
 	sh:xone (
-    [
-			sh:property [
-				a sh:PropertyShape ;
-	    	sh:path odrl:rightOperand ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
-        sh:severity sh:Violation ;
-				sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/contract/ConstraintShape.ttl> (ConstraintShape): Exactly one odrl:rightOperand property must point from an ids::Constraint to Literals or rdfs:Resources. Note that odrl:rightOperand and odrl:rightOperandReference cannot be used in the same statement."@en ;
+    			[
+				sh:property [
+					a sh:PropertyShape ;
+	    				sh:path odrl:rightOperand ;
+        				sh:minCount 1 ;
+        				sh:maxCount 1 ;
+        				sh:severity sh:Violation ;
+					sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/contract/ConstraintShape.ttl> (ConstraintShape): Exactly one odrl:rightOperand property must point from an ids::Constraint to Literals or rdfs:Resources. Note that odrl:rightOperand and odrl:rightOperandReference cannot be used in the same statement."@en ;
+				]
 			]
-		]
-    [
-			sh:property [
-				a sh:PropertyShape ;
-        sh:path odrl:rightOperandReference ;
-        sh:nodeKind sh:IRI ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
-        sh:severity sh:Violation ;
-				sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/contract/ConstraintShape.ttl> (ConstraintShape): Exactly one odrl:rightOperandReference property must point from an ids::Constraint to an IRI. Note that odrl:rightOperand and odrl:rightOperandReference cannot be used in the same statement."@en ;
+    			[
+				sh:property [
+					a sh:PropertyShape ;
+        				sh:path odrl:rightOperandReference ;
+        				sh:nodeKind sh:IRI ;
+        				sh:minCount 1 ;
+        				sh:maxCount 1 ;
+        				sh:severity sh:Violation ;
+					sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/contract/ConstraintShape.ttl> (ConstraintShape): Exactly one odrl:rightOperandReference property must point from an ids::Constraint to an IRI. Note that odrl:rightOperand and odrl:rightOperandReference cannot be used in the same statement."@en ;
+				]
 			]
-		]
 	) ;
 
 	sh:property [
@@ -83,7 +83,6 @@ shapes:ConstraintShape
 		a sh:PropertyShape ;
 		sh:path ids:pipEndpoint ;
 		sh:class ids:PIP ;
-		sh:minCount 1 ;
 		sh:maxCount 1 ;
 		sh:severity sh:Violation ;
 		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/contract/ConstraintShape.ttl> (ConstraintShape): An ids:pipEndpoint property must have exactly one point from an odrl:Constraint to an ids:PIP."@en ;
@@ -95,27 +94,27 @@ shapes:LogicalConstraintShape
 		a sh:NodeShape ;
 		sh:targetClass odrl:LogicalConstraint ;
 		sh:xone (
-	    [
-		    sh:path odrl:and ;
-        sh:minCount 1 ;
-        #sh:maxCount 1 ;
-				sh:class odrl:Constraint ;
-        sh:severity sh:Violation ;
-	    ]
-	    [
-		    sh:path odrl:or ;
-        sh:minCount 1 ;
-        #sh:maxCount 1 ;
-				sh:class odrl:Constraint ;
-        sh:severity sh:Violation ;
-	    ]
-	    [
-		    sh:path odrl:xone ;
-        sh:minCount 1 ;
-        #sh:maxCount 1 ;
-				sh:class odrl:Constraint ;
-        sh:severity sh:Violation ;
-	    ]
+		    [
+			sh:path odrl:and ;
+			sh:minCount 1 ;
+			#sh:maxCount 1 ;
+			sh:class odrl:Constraint ;
+			sh:severity sh:Violation ;
+		    ]
+		    [
+			sh:path odrl:or ;
+			sh:minCount 1 ;
+			#sh:maxCount 1 ;
+			sh:class odrl:Constraint ;
+			sh:severity sh:Violation ;
+		    ]
+		    [
+			sh:path odrl:xone ;
+			sh:minCount 1 ;
+			#sh:maxCount 1 ;
+			sh:class odrl:Constraint ;
+			sh:severity sh:Violation ;
+		    ]
 		) ;
 		sh:message "<https://raw.githubusercontent.com/International-Data-Spaces-Association/InformationModel/master/testing/contract/ConstraintShape.ttl> (LogicalConstraintShape): Exactly one odrl:and, odrl:or, or odrl:xone property must point from an odrl:LogicalConstraint to odrl:Constraint."@en ;
 .


### PR DESCRIPTION
There must be a possibility to create a Constraint without any pipEndpoint attribute. (And some further formatting suggestions to look better in the browser.)